### PR TITLE
Add placeids column

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -93,6 +93,7 @@ CREATE TABLE computedtiles (
     topiclangcode text,
     insertion_time timestamp,
     heatmap text,
+    placeids frozen<set<text>>,
     computedfeatures frozen<features>,
     PRIMARY KEY ((tilex, tiley, tilez), periodstartdate, periodenddate, pipeline, sourceid, topic)
 );


### PR DESCRIPTION
As noted in [project-fortis-spark#17](https://github.com/CatalystCode/project-fortis-spark/issues/17), this column is required to implement the [popularLocations](https://github.com/CatalystCode/project-fortis-services/blob/da74996a84d786f867bb09a4739d0f5401776d5a/src/resolvers-cassandra/Edges.js#L26) query in the project-fortis-services [EdgesSchema](https://github.com/CatalystCode/project-fortis-services/blob/da74996a84d786f867bb09a4739d0f5401776d5a/src/schemas/EdgesSchema.js#L7-L8).

Basically, to implement the query, we'll first fetch the geofence for the current site and then query the computedtiles table for those tiles inside of the geofence and then return the union of places contained in all the tiles.