### PR TITLE
Add index on tileid

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -98,6 +98,7 @@ CREATE TABLE computedtiles (
     PRIMARY KEY ((tilex, tiley, tilez), periodstartdate, periodenddate, pipeline, sourceid, topic)
 );
 
+CREATE INDEX ON computedtiles (tileid);
 CREATE INDEX ON computedtiles (period);
 CREATE INDEX ON computedtiles (computedfeatures);
 CREATE INDEX ON computedtiles (periodtype);


### PR DESCRIPTION
We have quite a few queries that need to look up all the tiles in a particular bounding box. It's fast to convert a bounding box to tile ids (can be done analytically) so we need to ensure that it's also fast to look up data by tile ids.