### PR TITLE
Make sure to create db and feature service user

### DIFF
--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -43,7 +43,7 @@ curl "${pg_dump}" | gunzip --to-stdout > "${dbdump}"
 echo "Finished. Now populating the database"
 pg_host="$(az postgres server show --resource-group "${resource_group}" --name "${pg_name}" | jq -r '.fullyQualifiedDomainName')"
 
-echo "CREATE DATABASE ${pg_dbname}; CREATE USER ${pg_user} PASSWORD '${pg_user_password}';" | \
+echo "CREATE DATABASE ${pg_dbname}; CREATE USER ${pg_user} WITH login PASSWORD '${pg_user_password}';" | \
 PGPASSWORD="${pg_admin_password}" psql \
   --host "${pg_host}" \
   --port 5432 \

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -5,11 +5,14 @@ readonly resource_group="$2"
 
 readonly pg_dump="https://fortiscentral.blob.core.windows.net/locations/feature-service.v1.sql.gz"
 readonly pg_admin="${FEATUREDB_ADMIN:-fortisadmin}"
+readonly pg_user="${FEATUREDB_USER:-frontend}"
 readonly pg_name="${FEATUREDB_NAME:-fortis-feature-service-db}"
 readonly pg_tier="${FEATUREDB_TIER:-Basic}"
 readonly pg_compute="${FEATUREDB_COMPUTEUNITS:-50}"
 readonly pg_version="${FEATUREDB_POSTGRESVERSION:-9.6}"
-readonly pg_password="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${PASSWORD_COMPLEXITY:-32}")"
+readonly pg_dbname="${FEATUREDB_DBNAME:geofeatures}"
+readonly pg_user_password="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${PASSWORD_COMPLEXITY:-32}")"
+readonly pg_admin_password="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${PASSWORD_COMPLEXITY:-32}")"
 
 if ! (command -v jq >/dev/null); then sudo apt-get install -y jq; fi
 if ! (command -v psql >/dev/null); then sudo apt-get install -y postgresql postgresql-contrib; fi
@@ -20,7 +23,7 @@ az postgres server create \
   --name "${pg_name}" \
   --location "${location}" \
   --admin-user "${pg_admin}" \
-  --admin-password "${pg_password}" \
+  --admin-password "${pg_admin_password}" \
   --performance-tier "${pg_tier}" \
   --compute-units "${pg_compute}" \
   --version "${pg_version}"
@@ -39,14 +42,24 @@ curl "${pg_dump}" | gunzip --to-stdout > "${dbdump}"
 
 echo "Finished. Now populating the database"
 pg_host="$(az postgres server show --resource-group "${resource_group}" --name "${pg_name}" | jq -r '.fullyQualifiedDomainName')"
-<"${dbdump}" PGPASSWORD="${pg_password}" psql \
+
+echo "CREATE DATABASE ${pg_dbname}; CREATE USER ${pg_user} PASSWORD ${pg_user_password};" | \
+PGPASSWORD="${pg_admin_password}" psql \
   --host "${pg_host}" \
   --port 5432 \
   --username "${pg_admin}@${pg_name}" \
   --quiet
+
+<"${dbdump}" \
+PGPASSWORD="${pg_admin_password}" psql \
+  --host "${pg_host}" \
+  --port 5432 \
+  --username "${pg_admin}@${pg_name}" \
+  --dbname "${pg_dbname}" \
+  --quiet
 rm "${dbdump}"
 
-FEATURE_SERVICE_DB_CONNECTION_STRING="postgres://${pg_admin}@${pg_name}:${pg_password}@${pg_host}:5432/features?ssl=true"
+FEATURE_SERVICE_DB_CONNECTION_STRING="postgres://${pg_user}@${pg_name}:${pg_admin_password}@${pg_host}:5432/${pg_dbname}?ssl=true"
 export FEATURE_SERVICE_DB_CONNECTION_STRING
 
 echo "All done installing feature service database"

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -43,7 +43,7 @@ curl "${pg_dump}" | gunzip --to-stdout > "${dbdump}"
 echo "Finished. Now populating the database"
 pg_host="$(az postgres server show --resource-group "${resource_group}" --name "${pg_name}" | jq -r '.fullyQualifiedDomainName')"
 
-echo "CREATE DATABASE ${pg_dbname}; CREATE USER ${pg_user} PASSWORD ${pg_user_password};" | \
+echo "CREATE DATABASE ${pg_dbname}; CREATE USER ${pg_user} PASSWORD '${pg_user_password}';" | \
 PGPASSWORD="${pg_admin_password}" psql \
   --host "${pg_host}" \
   --port 5432 \


### PR DESCRIPTION
In [featuresService#3](https://github.com/CatalystCode/featureService/pull/3), the hard-coded `frontend` user was removed from the feature service schema so that we avoid having to hard-code a password. This means that the database dump no longer contains the user definition. As such, the database setup script needs to create the correct users which is what this pull request implements.