### PR TITLE
Integrating service bus queues with fortis deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Project Fortis is a data ingestion, analysis and visualization pipeline. The Fo
   * Health
 
 ## Post Deployment Instructions
-* Expect the deployment to run for about an hour, so grab a cup of coffee once you kickoff the deployment. 
+* Grab a large cup of coffee as the deployment can take north of an hour to complete. 
 * Once the deployment has finished, click on the `Manage your resources`(highlighted below). 
 ![image](https://user-images.githubusercontent.com/7635865/27893300-7a5d32c2-61ca-11e7-9413-50a3b125f9f1.png)
 * Select the Deployment tab in the Azure Portal, then the `fortis-containers###` deployment and copy the Fortis Admin Interface URL in the output section of the deployment summary. 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ Deploy your own Fortis pipeline to an azure subscription through a single click.
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.svg)](https://deploy.azure.com/?repository=https://github.com/catalystcode/fortis-containers/tree/master?ptmpl=azuredeploy.parameters.json)
 
 ## Background
-Project Fortis is a data ingestion, analysis and visualization pipeline. The pipeline collects social media conversations and postings from the public web and darknet data sources. 
+Project Fortis is a data ingestion, analysis and visualization pipeline. The Fortis pipeline collects social media conversations and postings from the public web and darknet data sources. 
 
 ![image](https://user-images.githubusercontent.com/7635865/27882830-e785819c-6193-11e7-9b27-5fc452f23b1a.png)
 
-## Deployment Prerequisite 
-* An existing azure subscription. You can create one for free [here](https://azure.microsoft.com/en-us/free/). 
+## Deployment Prerequisites
+* First and foremost, you'll need an existing azure subscription. You can create one for free [here](https://azure.microsoft.com/en-us/free/). 
 * Generate a Public / Private ssh key pair following [these](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) instructions. The contents from the generated `MyKey.pub` file will be used for the `SSh Public Key` field. 
 * An existing azure service principal. You can create one following these [instructions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal). Your service principles `Application ID` will be used for the `Service Principal App ID` field, and the `Authentication Key` will be used for the `Service Principal App Key`. 
 
 ## Fortis Monitored Data Sources
+
 * Public Web - Bing
 * Reddit
 * Twitter
@@ -24,6 +25,16 @@ Project Fortis is a data ingestion, analysis and visualization pipeline. The pi
 * Radio Broadcasts
 * ACLED
 
+## Site Types
+* The site type selection drives which default topics, public sites and facebook pages are auto-generated for your site as part of the deployment process.
+* Available site types
+  * Humanitarian
+  * Climate Change
+  * Health
+
 ## Post Deployment Instructions
-* Expect the deployment to run between 30 - 45 minutes, so grab a cup of coffee once you kickoff the deployment. 
-* Click on the `Manage your deployment` link once the deployment completes. Select the Deployment tab in the Azure Portal and copy the Fortis Admin Interface URL in the output section of the deployment summary. 
+* Expect the deployment to run for about an hour, so grab a cup of coffee once you kickoff the deployment. 
+* Once the deployment has finished, click on the `Manage your resources`(highlighted below). 
+![image](https://user-images.githubusercontent.com/7635865/27893300-7a5d32c2-61ca-11e7-9413-50a3b125f9f1.png)
+* Select the Deployment tab in the Azure Portal, then the `fortis-containers###` deployment and copy the Fortis Admin Interface URL in the output section of the deployment summary. 
+![image](https://user-images.githubusercontent.com/7635865/27909039-66951d0a-6214-11e7-998b-be5603c4949b.png)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Project Fortis is a data ingestion, analysis and visualization pipeline. The Fo
 ## Deployment Prerequisites
 * First and foremost, you'll need an existing azure subscription. You can create one for free [here](https://azure.microsoft.com/en-us/free/). 
 * Generate a Public / Private ssh key pair following [these](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) instructions. The contents from the generated `MyKey.pub` file will be used for the `SSh Public Key` field. 
-* An existing azure service principal. You can create one following these [instructions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal). Your service principles `Application ID` will be used for the `Service Principal App ID` field, and the `Authentication Key` will be used for the `Service Principal App Key`. 
+* You'll need an existing azure service principal. You can follow these [instructions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal) if you need to generate a new service principal. Your service principles `Application ID` will be used for the `Service Principal App ID` field, and the `Authentication Key` will be used for the `Service Principal App Key`. 
 
 ## Fortis Monitored Data Sources
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -97,6 +97,7 @@
         "deploymentVmSize": "Standard_D2_v2",
         "deploymentUbuntuOSVersion": "16.04.0-LTS",
         "imagePublisher": "Canonical",
+        "deisStorageAcctName": "k8deisstorage",
         "imageOffer": "UbuntuServer",
 	    "vmStorageAccountContainerName": "vhds",
         "nicName": "fortisVMNic",
@@ -110,6 +111,7 @@
         "addressPrefix": "10.0.0.0/16",
         "publicIPAddressName": "fortisDeployPublicIP",
         "subnetName": "Subnet",
+        "sbVersion": "2017-04-01",
         "subnetPrefix": "10.0.0.0/24",
         "publicIPAddressType": "Dynamic",
         "virtualNetworkName": "FortisVNet",
@@ -118,9 +120,14 @@
         "postDeploymentGithubRepoPath": "https://raw.githubusercontent.com/CatalystCode/fortisdeploy/master",
         "postDeploymentExtensionScript": "fortis-deploy.sh",
         "githubClonePath":  "https://github.com/CatalystCode/fortisdeploy.git",
+        "sbNamespace": "fortisservicebusns",
+        "sbQueueNameSiteSettings": "siteMutations",
+        "sbQueueNameStreams": "streamMutations",
+        "sbAuthRuleResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', variables('sbNamespace'), variables('defaultSASKeyName'))]",
+        "defaultSASKeyName": "RootManageSharedAccessKey",
+        "sbAuthRuleName": "[concat(variables('sbNamespace'),'/fortisAuthRule')]",
         "eventHubNamespace": "fortiseventhubns",
         "eventHubName": "published-messages",
-        "eventhubAccessClaimType": "RootManageSharedAccessKey",
         "eventHubMessagingUnits": "1",
         "eventHubSku": "2",
         "eventhubResource": "[resourceId('Microsoft.Eventhub/namespaces/authorizationRules', variables('eventHubNamespace'), 'fortisAuthRule')]",
@@ -206,6 +213,42 @@
             },
             "kind": "Storage",
             "properties": {}
+        },
+        {
+        "apiVersion": "[variables('sbVersion')]",
+        "name": "[parameters('sbNamespace')]",
+        "type": "Microsoft.ServiceBus/namespaces",
+        "location": "[resourceGroup().location]",
+        "resources": [
+            {
+                "apiVersion": "[variables('sbVersion')]",
+                "name": "[parameters('sbQueueNameStreams')]",
+                "type": "Queues",
+                "dependsOn": [
+                    "[concat('Microsoft.ServiceBus/namespaces/', parameters('sbNamespace'))]"
+                ]
+            },
+            {
+                "apiVersion": "[variables('sbVersion')]",
+                "name": "[parameters('sbQueueNameSiteSettings')]",
+                "type": "Queues",
+                "dependsOn": [
+                    "[concat('Microsoft.ServiceBus/namespaces/', parameters('sbNamespace'))]"
+                ]
+            },
+            {
+                "apiVersion": "[variables('sbVersion')]",
+                "name": "[variables('sbAuthRuleName')]",
+                "type": "Microsoft.ServiceBus/namespaces/authorizationRules",
+                    "dependsOn": [
+                        "[concat('Microsoft.ServiceBus/namespaces/', variables('sbNamespace'))]"
+                    ],
+                    "location": "[resourceGroup().location]",
+                    "properties": {
+                        "Rights": [ "Send", "Listen", "Manage" ]
+                    }
+            }
+        ]
         },
         {
             "apiVersion": "[variables('ehVersion')]",
@@ -422,7 +465,7 @@
                     "fileUris": [
                         "[concat(variables('postDeploymentGithubRepoPath'),'/', variables('postDeploymentExtensionScript'))]"
                     ],
-                    "commandToExecute": "[concat('./', variables('postDeploymentExtensionScript'), ' -lo \"', resourceGroup().location, '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -sn \"', parameters('siteName'), '\" -un \"', parameters('adminUsername'), '\" -aii \"', reference(resourceId('Microsoft.Insights/components', variables('applicationInsightServiceName')), '2014-04-01').InstrumentationKey,'\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value,'\" -sty \"', parameters('siteType'), '\" -ai \"', parameters('servicePrincipalAppId'), '\" -sw \"', parameters('sparkWorkers'), '\" -cn \"', parameters('cassandraNodes'), '\" -kn \"', variables('kubernetesName'), '\" -pf \"', parameters('dnsNamePrefix'), '\" -ec \"', listKeys(variables('eventhubResource'), variables('ehVersion')).primaryConnectionString, '\" -gc \"', variables('githubClonePath'), '\"')]"
+                    "commandToExecute": "[concat('./', variables('postDeploymentExtensionScript'), ' -lo \"', resourceGroup().location, '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -sn \"', parameters('siteName'), '\" -un \"', parameters('adminUsername'), '\" -aii \"', reference(resourceId('Microsoft.Insights/components', variables('applicationInsightServiceName')), '2014-04-01').InstrumentationKey,'\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value,'\" -sty \"', parameters('siteType'), '\" -ai \"', parameters('servicePrincipalAppId'), '\" -sw \"', parameters('sparkWorkers'), '\" -cn \"', parameters('cassandraNodes'), '\" -kn \"', variables('kubernetesName'), '\" -pf \"', parameters('dnsNamePrefix'), '\" -ec \"', listKeys(variables('eventhubResource'), variables('ehVersion')).primaryConnectionString, '\" -sb \"', listkeys(variables('sbAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString, '\" -gc \"', variables('githubClonePath'), '\"')]"
                 }
             }
         }
@@ -431,6 +474,10 @@
         "kubernetesMasterFQDN": {
             "type": "string",
             "value": "[reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn]"
+        },
+        "fortisAdminSiteURL": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('deisStorageAcctName'))).tags.FORTIS_ADMIN_INTERFACE_HOST]"
         },
         "agentFQDN": {
             "type": "string",

--- a/fortis-deploy.sh
+++ b/fortis-deploy.sh
@@ -25,6 +25,7 @@ Arguments
   --prefix|-pf                       [Required] : Fortis Site Prefix
   --site_name|sn                     [Required] : Fortis Site Name
   --eh_conn_str|ec                   [Required] : Event Hub Connection String
+  --sb_conn_str|sb                   [Required] : Service Bus Connection String
 EOF
 }
 
@@ -69,6 +70,10 @@ do
       ;;
     --eh_conn_str|-ec)
       eh_conn_str="$1"
+      shift
+      ;;
+    --sb_conn_str|-sb)
+      sb_conn_str="$1"
       shift
       ;;
     --resource_group|-rg)
@@ -211,6 +216,7 @@ throw_if_empty --site_type "${site_type}"
 throw_if_empty --prefix "${prefix}"
 throw_if_empty --site_name "${site_name}"
 throw_if_empty --eh_conn_str "${eh_conn_str}"
+throw_if_empty --sb_conn_str "${sb_conn_str}"
 
 readonly kube_config_dest_file="/home/${user_name}/.kube/config"
 
@@ -253,4 +259,4 @@ readonly k8spark_worker_count="${spark_worker_count}"
 readonly k8resource_group="${resource_group}"
 
 chmod 752 create-cluster.sh
-./create-cluster.sh "${k8location}" "${k8cassandra_node_count}" "${k8spark_worker_count}" "${k8resource_group}" "${storage_account_name}" "${app_insights_id}" "${site_name}" "${eh_conn_str}"
+./create-cluster.sh "${k8location}" "${k8cassandra_node_count}" "${k8spark_worker_count}" "${k8resource_group}" "${storage_account_name}" "${app_insights_id}" "${site_name}" "${eh_conn_str}" "${sb_conn_str}"

--- a/ops/create-cluster.sh
+++ b/ops/create-cluster.sh
@@ -8,6 +8,7 @@ readonly storage_account_name="$5"
 readonly app_insights_id="$6"
 readonly site_name="$7"
 readonly eh_conn_str="$8"
+readonly sb_conn_str="$9"
 
 chmod -R 752 .
 
@@ -61,7 +62,7 @@ echo "Finished. Installing cassandra cqlsh cli."
 ./storage-ddls/install-cassandra-ddls.sh "${cassandra_host}"
 kubectl create -f ./spark-namespace.yaml
 echo "Finished. Deploying environment settings to cluster."
-./setup-environment.sh "${cassandra_host}" "${app_insights_id}" "${site_name}" "${feature_service_host}" "${spark_config_map_name}" "${graphql_service_host}" "${k8resource_group}" "${fortis_interface_host}" "${eh_conn_str}" "${feature_service_db_conn_str}" "${fortis_central_directory}"
+./setup-environment.sh "${cassandra_host}" "${app_insights_id}" "${site_name}" "${feature_service_host}" "${spark_config_map_name}" "${graphql_service_host}" "${k8resource_group}" "${fortis_interface_host}" "${eh_conn_str}" "${feature_service_db_conn_str}" "${fortis_central_directory}" "${sb_conn_str}"
 
 echo "Finished. Installing spark cluster."
 ./install-spark.sh "${k8spark_worker_count}" "${spark_config_map_name}" "${fortis_central_directory}"

--- a/ops/setup-environment.sh
+++ b/ops/setup-environment.sh
@@ -25,8 +25,22 @@ readonly sb_queue_site="siteMutations"
 readonly sb_queue_streams="streamMutations"
 readonly fortis_models_directory="${fortis_central_directory}/sentiment/"
 
-kubectl create configmap "${spark_config_map_name}" --namespace spark --from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" --from-literal=FORTIS_FEATURE_SERVICE_HOST="${feature_service_host}" --from-literal=DEFAULT_SITE_NAME="${site_name}" --from-literal=FORTIS_APPINSIGHTS_IKEY="${app_insights_id}" --from-literal=SPARK_DAEMON_MEMORY="${SPARK_DAEMON_MEMORY}" --from-literal=HA_PROGRESS_DIR="${checkpoint_directory}" --from-literal=DEFAULT_LANGUAGE="${default_language}" --from-literal=FORTIS_SERVICE_HOST="${graphql_service_host}" --from-literal=FORTIS_MODELS_DIRECTORY="${fortis_models_directory}" --from-literal=SERVICE_BUS_CONNECTION_STRING="${sb_conn_str}" --from-literal=SERVICE_BUS_QUEUE_SITE="${sb_queue_site}" --from-literal=SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}"
---from-literal=PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"
+kubectl create configmap "${spark_config_map_name}" --namespace spark \
+--from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" \
+--from-literal=FORTIS_FEATURE_SERVICE_HOST="${feature_service_host}" \
+--from-literal=DEFAULT_SITE_NAME="${site_name}" \
+--from-literal=FORTIS_APPINSIGHTS_IKEY="${app_insights_id}" \
+--from-literal=SPARK_DAEMON_MEMORY="${SPARK_DAEMON_MEMORY}" \
+--from-literal=HA_PROGRESS_DIR="${checkpoint_directory}" \
+--from-literal=DEFAULT_LANGUAGE="${default_language}" \
+--from-literal=FORTIS_SERVICE_HOST="${graphql_service_host}" \
+--from-literal=FORTIS_MODELS_DIRECTORY="${fortis_models_directory}" \
+--from-literal=SERVICE_BUS_CONNECTION_STRING="${sb_conn_str}" \
+--from-literal=SERVICE_BUS_QUEUE_SITE="${sb_queue_site}" \
+--from-literal=SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}"
+--from-literal=PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}" \
+--from-literal=PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}" \
+--from-literal=PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"
 
 cd deis-apps/feature-service || exit 2
 deis config:set APPINSIGHTS_INSTRUMENTATIONKEY="${app_insights_id}"

--- a/ops/setup-environment.sh
+++ b/ops/setup-environment.sh
@@ -14,15 +14,19 @@ readonly fortis_interface_host="${8}"
 readonly eh_conn_str="${9}"
 readonly feature_service_db_conn_str="${10}"
 readonly fortis_central_directory="${11}"
+readonly sb_conn_str="${12}"
 
 readonly fortis_admin_interface="http://${fortis_interface_host}/#/site/${site_name}/admin"
 readonly default_language="en"
 readonly checkpoint_directory="HDFS://"
 readonly eh_path="published-messages"
 readonly eh_consumer_group="\$Default"
+readonly sb_queue_site="siteMutations"
+readonly sb_queue_streams="streamMutations"
 readonly fortis_models_directory="${fortis_central_directory}/sentiment/"
 
-kubectl create configmap "${spark_config_map_name}" --namespace spark --from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" --from-literal=FORTIS_FEATURE_SERVICE_HOST="${feature_service_host}" --from-literal=DEFAULT_SITE_NAME="${site_name}" --from-literal=FORTIS_APPINSIGHTS_IKEY="${app_insights_id}" --from-literal=SPARK_DAEMON_MEMORY="${SPARK_DAEMON_MEMORY}" --from-literal=HA_PROGRESS_DIR="${checkpoint_directory}" --from-literal=DEFAULT_LANGUAGE="${default_language}" --from-literal=FORTIS_SERVICE_HOST="${graphql_service_host}" --from-literal=FORTIS_MODELS_DIRECTORY="${fortis_models_directory}" --from-literal=PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"
+kubectl create configmap "${spark_config_map_name}" --namespace spark --from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" --from-literal=FORTIS_FEATURE_SERVICE_HOST="${feature_service_host}" --from-literal=DEFAULT_SITE_NAME="${site_name}" --from-literal=FORTIS_APPINSIGHTS_IKEY="${app_insights_id}" --from-literal=SPARK_DAEMON_MEMORY="${SPARK_DAEMON_MEMORY}" --from-literal=HA_PROGRESS_DIR="${checkpoint_directory}" --from-literal=DEFAULT_LANGUAGE="${default_language}" --from-literal=FORTIS_SERVICE_HOST="${graphql_service_host}" --from-literal=FORTIS_MODELS_DIRECTORY="${fortis_models_directory}" --from-literal=SERVICE_BUS_CONNECTION_STRING="${sb_conn_str}" --from-literal=SERVICE_BUS_QUEUE_SITE="${sb_queue_site}" --from-literal=SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}"
+--from-literal=PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}" --from-literal=PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"
 
 cd deis-apps/feature-service || exit 2
 deis config:set APPINSIGHTS_INSTRUMENTATIONKEY="${app_insights_id}"
@@ -37,6 +41,9 @@ deis config:set FORTIS_CENTRAL_ASSETS_HOST="${fortis_central_directory}"
 deis config:set PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}"
 deis config:set PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}"
 deis config:set PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"
+deis config:set SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}"
+deis config:set SERVICE_BUS_QUEUE_SITE="${sb_queue_site}"
+deis config:set SERVICE_BUS_CONNECTION_STRING="${sb_conn_str}"
 
 cd ../fortis-interface || exit 2
 deis config:set APPINSIGHTS_INSTRUMENTATIONKEY="${app_insights_id}"
@@ -46,6 +53,4 @@ deis config:set DEFAULT_SITE_NAME="${site_name}"
 cd ../../ || exit 2
 
 #Set the deployed service host url tag so we can output that on the deployment console to the user
-sudo az resource tag --tags FORTIS_SERVICE_HOST="${graphql_service_host}" -g "${k8resource_group}" -n k8deisstorage --resource-type "Microsoft.Storage/storageAccounts"
-sudo az resource tag --tags FORTIS_INTERFACE_HOST="${fortis_interface_host}" -g "${k8resource_group}" -n k8deisstorage --resource-type "Microsoft.Storage/storageAccounts"
-sudo az resource tag --tags FORTIS_ADMIN_INTERFACE_HOST="${fortis_admin_interface}" -g "${k8resource_group}" -n k8deisstorage --resource-type "Microsoft.Storage/storageAccounts"
+sudo az resource tag --tags FORTIS_INTERFACE_HOST="${fortis_interface_host}" FORTIS_ADMIN_INTERFACE_HOST="${fortis_admin_interface}" FORTIS_SERVICE_HOST="${graphql_service_host}" -g "${k8resource_group}" -n k8deisstorage --resource-type "Microsoft.Storage/storageAccounts"

--- a/ops/upgrade-spark.sh
+++ b/ops/upgrade-spark.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if ! (command -v jq >/dev/null); then sudo apt install jq; fi
+
+readonly gh_fortis_spark_repo_name="project-fortis-spark"
+readonly fortis_central_directory="$1"
+readonly k8spark_worker_count="$2"
+readonly ConfigMapName="$3"
+readonly fortis_spark_version="${4:-$(curl "https://api.github.com/repos/catalystcode/${gh_fortis_spark_repo_name}/releases/latest" | jq -r '.tag_name')}"
+readonly fortis_jar="fortis-${fortis_spark_version}.jar"
+readonly SparkCommand="wget \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\" && spark-submit --driver-memory 4g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis ${fortis_jar}"
+
+cd charts || exit -2
+
+helm upgrade --set Worker.Replicas="${k8spark_worker_count}" --set Master.ConfigMapName="${ConfigMapName}" --set Master.SparkSubmitCommand="${SparkCommand}" --name spark-cluster ./stable/spark --namespace spark
+
+cd .. || exit -2


### PR DESCRIPTION
This PR includes the following additions
1) Updated README
2) Added a service bus namespace and two SB queues to the ARM deployment. 
3) Threaded the primary connection string for the service bus namespace down throughout the deployment script to set the environment for DEIS and Kubernetes Spark. 
4) Added the Fortis admin interface URL as an output value for the deployment script.
5) Added a new script to upgrade the fortis fat jar version of spark.