### PR TITLE
Proposing streams uniqueness from (pipeline, connector, params) - no need for the surrogate key since it's inaccessible from GraphQL.

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -37,10 +37,9 @@ CREATE INDEX ON sitesettings (sitename);
 
 CREATE TABLE streams (
   pipeline text,
-  streamid uuid,
   connector text,
   params frozen<map<text, text>>,
-  PRIMARY KEY ((pipeline), streamid)
+  PRIMARY KEY ((pipeline), connector, params)
 );
 
 CREATE TABLE trustedsources (


### PR DESCRIPTION
While working on the `modifyTwitterAccounts` and `removeTwitterAccounts` GraphQL endpoints, I realized that we could potentially end up with records with the exact-same values with the exception of their surrogate key.

This would make it confusing since the user could end up with duplicates and attempting to delete one (by its params) would result in deleting all with the same parameter.