### PR TITLE
Cassandra table overhaul

### DIFF
--- a/ops/install-deis.sh
+++ b/ops/install-deis.sh
@@ -11,7 +11,6 @@ echo "creating deis storage account ${k8location}"
 id
 
 DEIS_STORAGE_ACCOUNT_KEY="$(az storage account keys list -n "${DEIS_STORAGE_ACCOUNT_NAME}" -g "${k8resource_group}" --query [0].value --output tsv)"
-export DEIS_STORAGE_ACCOUNT_KEY
 
 echo "starting deis installation using helm"
 helm repo add deis https://charts.deis.com/workflow

--- a/ops/setup-environment.sh
+++ b/ops/setup-environment.sh
@@ -37,7 +37,7 @@ kubectl create configmap "${spark_config_map_name}" --namespace spark \
 --from-literal=FORTIS_MODELS_DIRECTORY="${fortis_models_directory}" \
 --from-literal=SERVICE_BUS_CONNECTION_STRING="${sb_conn_str}" \
 --from-literal=SERVICE_BUS_QUEUE_SITE="${sb_queue_site}" \
---from-literal=SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}"
+--from-literal=SERVICE_BUS_QUEUE_STREAM="${sb_queue_streams}" \
 --from-literal=PUBLISH_EVENTS_EVENTHUB_CONNECTION_STRING="${eh_conn_str}" \
 --from-literal=PUBLISH_EVENTS_EVENTHUB_PATH="${eh_path}" \
 --from-literal=PUBLISH_EVENTS_EVENTHUB_PARTITION="${eh_consumer_group}"

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -187,10 +187,8 @@ WITH OPTIONS = {
 'mode': 'CONTAINS',
 'analyzer_class': 'org.apache.cassandra.index.sasi.analyzer.StandardAnalyzer',
 'analyzed': 'true',
-'tokenization_skip_stop_words': 'and, the, or',
 'tokenization_enable_stemming': 'true',
-'tokenization_normalize_lowercase': 'true',
-'tokenization_locale': 'en'
+'tokenization_normalize_lowercase': 'true'
 };
 
 CREATE CUSTOM INDEX ON events (title) USING 'org.apache.cassandra.index.sasi.SASIIndex'
@@ -198,8 +196,6 @@ WITH OPTIONS = {
 'mode': 'CONTAINS',
 'analyzer_class': 'org.apache.cassandra.index.sasi.analyzer.StandardAnalyzer',
 'analyzed': 'true',
-'tokenization_skip_stop_words': 'and, the, or',
 'tokenization_enable_stemming': 'true',
-'tokenization_normalize_lowercase': 'true',
-'tokenization_locale': 'en'
+'tokenization_normalize_lowercase': 'true'
 };

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -4,6 +4,7 @@ CREATE KEYSPACE fortis
 USE fortis;
 
 CREATE TABLE watchlist(
+    topicid uuid,
     keyword text,
     lang_code text,
     translations map<text, text>,
@@ -33,16 +34,16 @@ CREATE TABLE sitesettings(
 );
 
 CREATE TABLE streams (
-  streamid uuid,
-  pipelinekey text,
-  pipelinelabel text,
-  pipelineicon text,
-  streamfactory text,
-  params frozen<map<text, text>>,
-  PRIMARY KEY (pipelinekey, streamid)
+    streamid uuid,
+    pipelinekey text,
+    pipelinelabel text,
+    pipelineicon text,
+    streamfactory text,
+    params frozen<map<text, text>>,
+    PRIMARY KEY (pipelinekey, streamid)
 );
 
-CREATE TABLE trustedsources (
+CREATE TABLE trustedsources (   
    externalsourceid text,
    sourcetype text,
    streamfactory text,
@@ -75,75 +76,66 @@ CREATE TYPE features (
     entities frozen<set<computedentities>>
 );
 
-CREATE TABLE computedtiles (
-    tileid text,
-    tilex int,
-    tiley int,
-    tilez int,
-    periodstartdate timestamp,
-    periodenddate timestamp,
-    periodtype text,
-    period text,
-    pipelinekey text,
-    externalsourceid text,
-    topicconjunctionid uuid,
-    insertion_time timestamp,
-    heatmap text,
-    placeids frozen<set<text>>,
-    computedfeatures frozen<features>,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid), externalsourceid, tilez, tilex, tiley, periodstartdate, periodenddate)
-);
-
-create table topicconjunctions(
+DROP TABLE IF EXISTS conjunctivetopics;
+CREATE TABLE conjunctivetopics (
     topic text,
-    topicconjunctionid uuid,
-    conjunctivekeywordcombination map<text, int>,//map value is representative of the aggregated mention count displayed in the dashboard
-    PRIMARY KEY (topic, topicconjunctionid)
-);
+    conjunctivetopic text,
+    mentions int,
+    PRIMARY KEY(topic, mentions, conjunctivetopic)
+) WITH CLUSTERING ORDER BY(mentions DESC);
 
-CREATE INDEX ON topicconjunctions ( KEYS (conjunctivekeywordcombination) );
-
-CREATE TABLE computedplaces (
-    placeid text,
-    periodstartdate timestamp,
-    periodenddate timestamp,
-    periodtype text,
-    period text,
-    pipelinekey text,
-    externalsourceid text,
-    topicconjunctionid uuid,
-    insertion_time timestamp,
-    computedfeatures frozen<features>,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid, placeid), externalsourceid, periodstartdate, periodenddate)
-);
-
+DROP TABLE IF EXISTS populartopics;
 CREATE TABLE populartopics (
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
-    period text,
     pipelinekey text,
+    period text,
+    tilez int,
+    tilex int,
+    tiley int,
     externalsourceid text,
     topic text,
-    topiclangcode text,
     mentionCount int,
     insertion_time timestamp,
-    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, topiclangcode), mentionCount, periodstartdate, periodenddate, topic)
-) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, topic ASC);
+    PRIMARY KEY ((periodtype, pipelinekey, externalsourceid, tilez, topic, period), tilex, tiley, periodstartdate, periodenddate)
+);
 
-CREATE TABLE popularsources (
+DROP TABLE IF EXISTS computedtiles;
+CREATE TABLE computedtiles (
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
-    period text,
     pipelinekey text,
+    period text,
+    tilez int,
+    tilex int,
+    tiley int,
     externalsourceid text,
-    topicconjunctionid uuid,
-    mentionCount int,
+    mentioncount int,
+    avgsentiment int,
+    heatmap text,
+    placeids frozen<set<text>>,
     insertion_time timestamp,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid), mentionCount, periodstartdate, periodenddate, externalsourceid)
-) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, externalsourceid ASC);
+    conjunctiontopics tuple<text, text, text>,
+    PRIMARY KEY ((periodtype, conjunctiontopics, tilez, period), tilex, tiley, periodstartdate, periodenddate, pipelinekey, externalsourceid)
+);
 
+DROP MATERIALIZED VIEW IF EXISTS popularsources;
+CREATE MATERIALIZED VIEW popularsources
+AS SELECT periodtype, conjunctiontopics, tilez, externalsourceid, period, pipelinekey, conjunctiontopics, periodtype, tilez, period, tilex, tiley, periodstartdate, periodenddate, mentioncount
+   FROM computedtiles
+   WHERE periodtype IS NOT NULL AND conjunctiontopics IS NOT NULL AND tilez IS NOT NULL AND externalsourceid IS NOT NULL AND period IS NOT NULL AND pipelinekey IS NOT NULL AND conjunctiontopics IS NOT NULL AND periodtype IS NOT NULL AND tilez IS NOT NULL AND period IS NOT NULL AND tilex IS NOT NULL AND tiley IS NOT NULL AND periodstartdate IS NOT NULL AND periodenddate IS NOT NULL
+PRIMARY KEY ((periodtype, conjunctiontopics, tilez, externalsourceid, period), tilex, tiley, periodstartdate, periodenddate, pipelinekey);
+
+DROP MATERIALIZED VIEW IF EXISTS timeseries;
+CREATE MATERIALIZED VIEW timeseries
+AS SELECT periodtype, conjunctiontopics, tilez, externalsourceid, period, pipelinekey, conjunctiontopics, periodtype, tilez, period, tilex, tiley, periodstartdate, periodenddate, mentioncount, avgsentiment
+   FROM computedtiles
+   WHERE periodtype IS NOT NULL AND conjunctiontopics IS NOT NULL AND tilez IS NOT NULL AND externalsourceid IS NOT NULL AND period IS NOT NULL AND pipelinekey IS NOT NULL AND conjunctiontopics IS NOT NULL AND periodtype IS NOT NULL AND tilez IS NOT NULL AND period IS NOT NULL AND tilex IS NOT NULL AND tiley IS NOT NULL AND periodstartdate IS NOT NULL AND periodenddate IS NOT NULL
+PRIMARY KEY ((periodtype, conjunctiontopics, tilez, period), tilex, tiley, pipelinekey, externalsourceid, periodstartdate, periodenddate);
+
+DROP TABLE IF EXISTS popularplaces;
 CREATE TABLE popularplaces (
     periodstartdate timestamp,
     periodenddate timestamp,
@@ -152,29 +144,43 @@ CREATE TABLE popularplaces (
     pipelinekey text,
     externalsourceid text,
     placename text,
-    placeid int,
-    topicconjunctionid uuid,
-    mentionCount int,
+    placeid text,
+    placecentroidcoordx double,
+    placecentroidcoordy double,
+    conjunctiontopics tuple<text, text, text>,
+    mentioncount int,
     insertion_time timestamp,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid, externalsourceid), mentionCount, periodstartdate, periodenddate, placename)
-) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, placename ASC);
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopics), mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy)
+) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, placecentroidcoordx DESC, placecentroidcoordy DESC);
 
+DROP TABLE IF EXISTS eventtags;
+CREATE TABLE eventtags(
+    eventid uuid,
+    topic text,
+    placeid text,
+    placecentroidcoordx double,
+    placecentroidcoordy double,
+    event_time timestamp,
+    pipelinekey text,
+    externalsourceid text,
+    PRIMARY KEY (topic, pipelinekey, event_time, placecentroidcoordx, placecentroidcoordy, eventid)
+) WITH CLUSTERING ORDER BY (pipelinekey DESC, event_time ASC);
+
+DROP TABLE IF EXISTS events;
 CREATE TABLE events(
-    id uuid,
+    eventid uuid,
     externalid text,
     pipelinekey text,
     title text,
     sourceurl text,
-    detectedplaceids frozen<set<text>>,
     externalsourceid text,
-    topicconjunctionids set<text>,
     eventlangcode text,
     messagebody text,
     computedfeatures frozen<features>,
     insertion_time timestamp,
     event_time timestamp,
-    PRIMARY KEY ((pipelinekey, eventlangcode), externalid)
-);
+    PRIMARY KEY ((pipelinekey, eventid), event_time)
+) WITH CLUSTERING ORDER BY (event_time ASC);
 
 CREATE CUSTOM INDEX ON events (messagebody) USING 'org.apache.cassandra.index.sasi.SASIIndex'
 WITH OPTIONS = {
@@ -197,5 +203,3 @@ WITH OPTIONS = {
 'tokenization_normalize_lowercase': 'true',
 'tokenization_locale': 'en'
 };
-
-CREATE INDEX ON events (topicconjunctionids);

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -18,7 +18,6 @@ CREATE TABLE blacklist(
 );
 
 CREATE TABLE sitesettings(
-    id uuid,
     sitename text,
     geofence list<double>,
     languages set<text>,
@@ -34,17 +33,19 @@ CREATE TABLE sitesettings(
 );
 
 CREATE TABLE streams (
+  streamid uuid,
   pipelinekey text,
   pipelinelabel text,
-  connectorid uuid,
+  pipelineicon text,
+  streamfactory text,
   params frozen<map<text, text>>,
-  PRIMARY KEY (pipelinekey, connectorid)
+  PRIMARY KEY (pipelinekey, streamid)
 );
 
 CREATE TABLE trustedsources (
    externalsourceid text,
    sourcetype text,
-   pipelinekey text,
+   streamfactory text,
    rank int,
    insertion_time timestamp,
    PRIMARY KEY (pipelinekey, externalsourceid, sourcetype, rank)
@@ -85,19 +86,19 @@ CREATE TABLE computedtiles (
     period text,
     pipelinekey text,
     externalsourceid text,
-    topiconjunctionid uuid,
+    topicconjunctionid uuid,
     insertion_time timestamp,
     heatmap text,
     placeids frozen<set<text>>,
     computedfeatures frozen<features>,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid), externalsourceid, tilez, tilex, tiley, periodstartdate, periodenddate)
+    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid), externalsourceid, tilez, tilex, tiley, periodstartdate, periodenddate)
 );
 
 create table topicconjunctions(
     topic text,
     topicconjunctionid uuid,
     conjunctivekeywordcombination map<text, int>,//map value is representative of the aggregated mention count displayed in the dashboard
-    PRIMARY KEY (topic)
+    PRIMARY KEY (topic, topicconjunctionid)
 );
 
 CREATE INDEX ON topicconjunctions ( KEYS (conjunctivekeywordcombination) );
@@ -110,10 +111,10 @@ CREATE TABLE computedplaces (
     period text,
     pipelinekey text,
     externalsourceid text,
-    topiconjunctionid uuid,
+    topicconjunctionid uuid,
     insertion_time timestamp,
     computedfeatures frozen<features>,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid, placeid), externalsourceid, periodstartdate, periodenddate)
+    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid, placeid), externalsourceid, periodstartdate, periodenddate)
 );
 
 CREATE TABLE populartopics (
@@ -137,11 +138,26 @@ CREATE TABLE popularsources (
     period text,
     pipelinekey text,
     externalsourceid text,
-    topiconjunctionid uuid,
+    topicconjunctionid uuid,
     mentionCount int,
     insertion_time timestamp,
-    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid), mentionCount, periodstartdate, periodenddate, externalsourceid)
+    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid), mentionCount, periodstartdate, periodenddate, externalsourceid)
 ) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, externalsourceid ASC);
+
+CREATE TABLE popularplaces (
+    periodstartdate timestamp,
+    periodenddate timestamp,
+    periodtype text,
+    period text,
+    pipelinekey text,
+    externalsourceid text,
+    placename text,
+    placeid int,
+    topicconjunctionid uuid,
+    mentionCount int,
+    insertion_time timestamp,
+    PRIMARY KEY ((period, periodtype, pipelinekey, topicconjunctionid, externalsourceid), mentionCount, periodstartdate, periodenddate, placename)
+) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, placename ASC);
 
 CREATE TABLE events(
     id uuid,
@@ -151,13 +167,13 @@ CREATE TABLE events(
     sourceurl text,
     detectedplaceids frozen<set<text>>,
     externalsourceid text,
-    topiconjunctionid uuid,
+    topicconjunctionids set<text>,
     eventlangcode text,
     messagebody text,
     computedfeatures frozen<features>,
     insertion_time timestamp,
     event_time timestamp,
-    PRIMARY KEY ((pipelinekey, topiconjunctionid, eventlangcode), externalid)
+    PRIMARY KEY ((pipelinekey, eventlangcode), externalid)
 );
 
 CREATE CUSTOM INDEX ON events (messagebody) USING 'org.apache.cassandra.index.sasi.SASIIndex'
@@ -181,3 +197,5 @@ WITH OPTIONS = {
 'tokenization_normalize_lowercase': 'true',
 'tokenization_locale': 'en'
 };
+
+CREATE INDEX ON events (topicconjunctionids);

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -5,11 +5,11 @@ USE fortis;
 
 CREATE TABLE watchlist(
     topicid uuid,
-    keyword text,
+    topic text,
     lang_code text,
     translations map<text, text>,
     insertion_time timestamp,
-    PRIMARY KEY (keyword, lang_code)
+    PRIMARY KEY (topic, lang_code)
 );
 
 CREATE TABLE blacklist(

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -72,7 +72,7 @@ CREATE TYPE features (
     sentiment frozen<computedsentiment>,
     gender frozen<computedgender>,
     entities frozen<set<computedentities>>
-);  
+);
 
 CREATE TABLE computedtiles (
     tileid text,

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -93,14 +93,14 @@ CREATE TABLE computedtiles (
     PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid), externalsourceid, tilez, tilex, tiley, periodstartdate, periodenddate)
 );
 
-create table topiconjunctions(
+create table topicconjunctions(
     topic text,
-    topiconjunctionid uuid,
+    topicconjunctionid uuid,
     conjunctivekeywordcombination map<text, int>,//map value is representative of the aggregated mention count displayed in the dashboard
-    PRIMARY KEY ((topic, topiconjunctionid))
+    PRIMARY KEY (topic)
 );
 
-CREATE INDEX ON topiconjunctions ( KEYS (conjunctivekeywordcombination) );
+CREATE INDEX ON topicconjunctions ( KEYS (conjunctivekeywordcombination) );
 
 CREATE TABLE computedplaces (
     placeid text,

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -73,7 +73,7 @@ CREATE TYPE features (
     sentiment frozen<computedsentiment>,
     gender frozen<computedgender>,
     entities frozen<set<computedentities>>
-);  
+);
 
 CREATE TABLE computedtiles (
     tileid text,

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -30,29 +30,25 @@ CREATE TABLE sitesettings(
     cogvisionsvctoken text,
     cogtextsvctoken text,
     insertion_time timestamp,
-    PRIMARY KEY (id, sitename)
+    PRIMARY KEY (sitename)
 );
 
-CREATE INDEX ON sitesettings (sitename);
-
 CREATE TABLE streams (
-  pipeline text,
-  streamid uuid,
-  connector text,
+  pipelinekey text,
+  pipelinelabel text,
+  connectorid uuid,
   params frozen<map<text, text>>,
-  PRIMARY KEY ((pipeline), streamid)
+  PRIMARY KEY (pipelinekey, connectorid)
 );
 
 CREATE TABLE trustedsources (
-   sourceid text,
+   externalsourceid text,
    sourcetype text,
-   connector text,
+   pipelinekey text,
    rank int,
    insertion_time timestamp,
-   PRIMARY KEY ((connector), sourceid, sourcetype)
+   PRIMARY KEY (pipelinekey, externalsourceid, sourcetype, rank)
 );
-
-CREATE INDEX ON trustedsources (rank);
 
 CREATE TYPE computedsentiment (
     pos_avg float,
@@ -76,90 +72,112 @@ CREATE TYPE features (
     sentiment frozen<computedsentiment>,
     gender frozen<computedgender>,
     entities frozen<set<computedentities>>
-);
+);  
 
 CREATE TABLE computedtiles (
+    tileid text,
     tilex int,
     tiley int,
     tilez int,
-    tileid text,
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
     period text,
-    pipeline text,
-    sourceid text,
-    topic text,
-    topiclangcode text,
+    pipelinekey text,
+    externalsourceid text,
+    topiconjunctionid uuid,
     insertion_time timestamp,
     heatmap text,
     placeids frozen<set<text>>,
     computedfeatures frozen<features>,
-    PRIMARY KEY ((tilex, tiley, tilez), periodstartdate, periodenddate, pipeline, sourceid, topic)
+    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid), externalsourceid, tilez, tilex, tiley, periodstartdate, periodenddate)
 );
 
-CREATE INDEX ON computedtiles (tileid);
-CREATE INDEX ON computedtiles (period);
-CREATE INDEX ON computedtiles (computedfeatures);
-CREATE INDEX ON computedtiles (periodtype);
+create table topiconjunctions(
+    topic text,
+    topiconjunctionid uuid,
+    conjunctivekeywordcombination map<text, int>,//map value is representative of the aggregated mention count displayed in the dashboard
+    PRIMARY KEY ((topic, topiconjunctionid))
+);
+
+CREATE INDEX ON topiconjunctions ( KEYS (conjunctivekeywordcombination) );
 
 CREATE TABLE computedplaces (
     placeid text,
-    placename text,
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
     period text,
-    pipeline text,
-    sourceid text,
-    topic text,
-    topiclangcode text,
+    pipelinekey text,
+    externalsourceid text,
+    topiconjunctionid uuid,
     insertion_time timestamp,
     computedfeatures frozen<features>,
-    PRIMARY KEY ((placeid), periodstartdate, periodenddate, pipeline, sourceid, topic)
+    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid, placeid), externalsourceid, periodstartdate, periodenddate)
 );
 
-CREATE INDEX ON computedplaces (period);
-CREATE INDEX ON computedplaces (computedfeatures);
-CREATE INDEX ON computedplaces (periodtype);
-
-CREATE TABLE computedtopics (
+CREATE TABLE populartopics (
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
     period text,
-    pipeline text,
-    sourceid text,
+    pipelinekey text,
+    externalsourceid text,
     topic text,
     topiclangcode text,
+    mentionCount int,
     insertion_time timestamp,
-    computedfeatures frozen<features>,
-    PRIMARY KEY ((topic), pipeline, periodstartdate, periodenddate, sourceid)
-);
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, topiclangcode), mentionCount, periodstartdate, periodenddate, topic)
+) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, topic ASC);
 
-CREATE INDEX ON computedtopics (period);
-CREATE INDEX ON computedtopics (computedfeatures);
-CREATE INDEX ON computedtopics (periodtype);
+CREATE TABLE popularsources (
+    periodstartdate timestamp,
+    periodenddate timestamp,
+    periodtype text,
+    period text,
+    pipelinekey text,
+    externalsourceid text,
+    topiconjunctionid uuid,
+    mentionCount int,
+    insertion_time timestamp,
+    PRIMARY KEY ((period, periodtype, pipelinekey, topiconjunctionid), mentionCount, periodstartdate, periodenddate, externalsourceid)
+) WITH CLUSTERING ORDER BY (mentionCount DESC, periodstartdate DESC, periodenddate DESC, externalsourceid ASC);
 
 CREATE TABLE events(
     id uuid,
     externalid text,
-    pipeline text,
+    pipelinekey text,
     title text,
     sourceurl text,
     detectedplaceids frozen<set<text>>,
-    sourceid text,
-    detectedkeywords frozen<set<text>>,
+    externalsourceid text,
+    topiconjunctionid uuid,
     eventlangcode text,
     messagebody text,
     computedfeatures frozen<features>,
     insertion_time timestamp,
     event_time timestamp,
-    PRIMARY KEY (pipeline, externalid)
+    PRIMARY KEY ((pipelinekey, topiconjunctionid, eventlangcode), externalid)
 );
 
-CREATE INDEX ON events (FULL(detectedplaceids));
-CREATE INDEX ON events (FULL(detectedkeywords));
-CREATE INDEX ON events (computedfeatures);
-CREATE INDEX ON events (eventlangcode);
-CREATE INDEX ON events (event_time);
+CREATE CUSTOM INDEX ON events (messagebody) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+WITH OPTIONS = {
+'mode': 'CONTAINS',
+'analyzer_class': 'org.apache.cassandra.index.sasi.analyzer.StandardAnalyzer',
+'analyzed': 'true',
+'tokenization_skip_stop_words': 'and, the, or',
+'tokenization_enable_stemming': 'true',
+'tokenization_normalize_lowercase': 'true',
+'tokenization_locale': 'en'
+};
+
+CREATE CUSTOM INDEX ON events (title) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+WITH OPTIONS = {
+'mode': 'CONTAINS',
+'analyzer_class': 'org.apache.cassandra.index.sasi.analyzer.StandardAnalyzer',
+'analyzed': 'true',
+'tokenization_skip_stop_words': 'and, the, or',
+'tokenization_enable_stemming': 'true',
+'tokenization_normalize_lowercase': 'true',
+'tokenization_locale': 'en'
+};

--- a/ops/storage-ddls/cassandra-usage-queries.cql
+++ b/ops/storage-ddls/cassandra-usage-queries.cql
@@ -1,3 +1,8 @@
+insert into topicconjunctions (topic, computedfeatures, externalsourceid, periodstartdate, periodenddate, period, periodtype, pipelinekey) values ('isis', {mentions: 300}, 'all', '2017-06-01', '2017-06-30', 'month-2017-06', 'month', 'all');
+alter table topicconjunctions add(conj_topic_car features, conj_topic_bomb features);
+insert into topicconjunctions (topic, computedfeatures, conj_topic_car, conj_topic_bomb) values ('isis', {mentions: 350}, {mentions: 25}, {mentions: 25});
+insert into topicconjunctions (topic, computedfeatures, externalsourceid, periodstartdate, periodenddate, period, periodtype, pipelinekey, conj_topic_car, conj_topic_bomb) values ('isis', {mentions: 350}, 'all', '2017-06-01', '2017-06-30', 'month-2017-06', 'month', 'all', {mentions: 25}, {mentions: 25});
+
 insert into streams (streamid, pipelinekey, pipelinelabel, streamfactory, params) values (uuid(), 'instagram', 'Instagram', 'InstagramTag', {'connName':'Test'});
 insert into streams (streamid, pipelinekey, pipelinelabel, streamfactory, params) values (uuid(), 'instagram', 'Instagram', 'InstagramLocation', {'connName':'Test'});
 
@@ -30,26 +35,48 @@ insert into topicconjunctions(topic, topicconjunctionid, conjunctivekeywordcombi
 
 select * from topicconjunctions where topic = 'isis';
 
-insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topicconjunctionid, placename) VALUES ('232344', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'london';
+insert into populartopics (topic, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentioncount, insertion_time, tilez, tilex, tiley) values ('elections', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 400, dateof(now()), 8, 141, 43);
 
-insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topicconjunctionid, placename) VALUES ('34345', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'sydney');
+insert into populartopics (topic, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentioncount, insertion_time, tilez, tilex, tiley) values ('elections', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 600, dateof(now()), 8, 142, 43);
 
- select * from computedplaces where period = 'month-2017-06' and periodtype = 'month' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipelinekey = 'all' and externalsourceid='all' and placeid IN('34345') and (periodstartdate, periodenddate) >= ('2017-06-01', '2017-06-01') and (periodstartdate, periodenddate) <= ('2017-06-30', '2017-06-30');
+select periodtype, pipelinekey, externalsourceid, tilez, topic, period, sum(mentioncount) as mentions from populartopics where periodtype = 'month' and tilez = 8 and pipelinekey = 'all' and period IN('month-2017-06') and externalsourceid = 'all' and (tilex, tiley, periodstartdate, periodenddate) >= (140, 41, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (143, 44, '2017-06-30', '2017-06-30') group by periodtype, pipelinekey, externalsourceid, tilez, topic, period allow filtering;
 
-insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentionCount, insertion_time) values ('elections', 'en', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 400, dateof(now()));
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@bloomberg', 'twitter', ('isis', 'car'), 250, dateof(now()), 8, 141, 43);
 
-insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentionCount, insertion_time) values ('isis', 'en', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 100, dateof(now()));
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@cnn', 'twitter', ('isis', 'car'), 2501, dateof(now()), 8, 141, 41);
 
-select * from populartopics where topiclangcode = 'en' and period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'all' and externalsourceid = 'all' and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@cnn', 'twitter', ('isis', 'car'), 2501, dateof(now()), 8, 141, 42);
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@al jazeera', 'twitter', 400, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@cnn', 'twitter', ('isis', 'car'), 50, dateof(now()), 8, 142, 43);
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@bloomberg', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@cnn', 'twitter', ('isis', 'car'), 501, dateof(now()), 8, 140, 43);
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@reuters', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, conjunctiontopics, mentioncount, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@cnn', 'twitter', ('isis', 'car'), 250, dateof(now()), 8, 143, 43);
 
-select * from popularsources where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'twitter' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, mentioncount, conjunctiontopics, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@bloomberg', 'twitter', 150, ('clinton'), dateof(now()), 8, 141, 43);
 
-select * from popularplaces where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'all' and externalsourceid = 'all' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, mentioncount, conjunctiontopics, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@reuters', 'twitter', 150, ('isis', 'car'), dateof(now()), 8, 141, 43);
 
-select * from events where pipelinekey = 'twitter' and eventlangcode = 'en' and topicconjunctionids CONTAINS 'facd7900-55cb-4fc5-844a-555c354cfe02';
+insert into computedtiles (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, mentioncount, conjunctiontopics, insertion_time, tilez, tilex, tiley) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', '@reuters', 'twitter', 150, ('isis', 'car'), dateof(now()), 8, 141, 42);
+
+select periodtype, conjunctiontopics, tilez, externalsourceid, period, max(pipelinekey), sum(mentioncount) as mentions from popularsources where conjunctiontopics = ('isis', 'car') and periodtype = 'month' and tilez = 8 and pipelinekey = 'twitter' and period IN('month-2017-06') and (tilex, tiley, periodstartdate, periodenddate) >= (140, 41, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (143, 44, '2017-06-30', '2017-06-30') group by periodtype, conjunctiontopics, tilez, externalsourceid, period allow filtering;
+
+insert into popularplaces (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, mentioncount, conjunctiontopics, insertion_time, placeid, placecentroidcoordx, placecentroidcoordy, placename) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', 'all', 'all', 100, ('isis', 'car'), dateof(now()), '482804', 25.11222, -32.2333, 'London');
+
+insert into popularplaces (periodstartdate, periodenddate, period, periodtype, externalsourceid, pipelinekey, mentioncount, conjunctiontopics, insertion_time, placeid, placecentroidcoordx, placecentroidcoordy, placename) values ('2017-06-01', '2017-06-30', 'month-2017-06', 'month', 'all', 'all', 220, ('isis', 'car'), dateof(now()), '482808', 22.11222, -32.2333, 'Paris');
+
+select period, periodtype, pipelinekey, externalsourceid, conjunctiontopics, mentioncount, placename from popularplaces where conjunctiontopics = ('isis', 'car') and periodtype = 'month' and externalsourceid = 'all' and pipelinekey = 'all' and period IN('month-2017-06') and (mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy) >= (1, '2017-06-01', '2017-06-01', 22, -33) and (mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy) <= (100000000, '2017-06-30', '2017-06-30', 26, 0) LIMIT 1;
+
+insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, event_time, pipelinekey, externalsourceid) values (uuid(), 'isis', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
+
+insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, event_time, pipelinekey, externalsourceid) values (ac01cb69-1684-4b5e-9016-7a4f0dcde074, 'car', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
+
+select eventid, pipelinekey, event_time from eventtags where topic IN('isis', 'car') and pipelinekey IN('twitter', 'facebook') and (event_time, placecentroidcoordx, placecentroidcoordy) >= ('2017-06-01', 12, -46) and (event_time, placecentroidcoordx, placecentroidcoordy) <= ('2017-07-15', 12, -44);
+
+select * from events where eventid IN(609a367a-c536-46a9-aee0-415625e8ff43, 7c0933b9-f6d1-417a-a7b2-fb738aad441c) and pipelinekey IN('twitter');
+
+insert into conjunctivetopics (topic, conjunctivetopic, mentions) values ('isis', 'car', 45);
+insert into conjunctivetopics (topic, conjunctivetopic, mentions) values ('isis', 'bomb', 345);
+insert into conjunctivetopics (topic, conjunctivetopic, mentions) values ('isis', 'terror', 35);
+
+select * from conjunctivetopics where topic = 'isis';

--- a/ops/storage-ddls/cassandra-usage-queries.cql
+++ b/ops/storage-ddls/cassandra-usage-queries.cql
@@ -8,29 +8,14 @@ insert into streams (streamid, pipelinekey, pipelinelabel, streamfactory, params
 
 select * from streams where pipelinekey = 'instagram';
 
- pipelinekey | streamfactory     | params               | pipelineicon | pipelinelabel
--------------+-------------------+----------------------+--------------+---------------
-   instagram | InstagramLocation | {'connName': 'Test'} |         null |     Instagram
-   instagram |      InstagramTag | {'connName': 'Test'} |         null |     Instagram
-
-(2 rows)
-
 insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('@bloomberg', 'profile', 'twitter', 1, dateof(now()));
 insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('kevhartman', 'profile', ' ', 1, dateof(now()));
-cassandra@cqlsh:fortis> select * from trustedsources where pipelinekey = 'twitter' ;
-
- pipelinekey | externalsourceid | sourcetype | rank | insertion_time
--------------+------------------+------------+------+---------------------------------
-     twitter |       @aljazeera |    profile |    1 | 2017-07-12 02:19:15.922000+0000
-     twitter |       @bloomberg |    profile |    1 | 2017-07-12 02:20:23.430000+0000
-     twitter |             @cnn |    profile |    2 | 2017-07-12 02:19:40.007000+0000
-
+select * from trustedsources where pipelinekey = 'twitter' ;
 
 insert into computedtiles (tileid, tilex, tiley, tilez, periodstartdate, periodenddate, periodtype, period, pipeline, sourceid, topicconjunctionid) VALUES ('100_105_16', 100, 106, 16, '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02);
 
  select * from computedtiles where period = 'month-2017-06' and periodtype = 'month' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipeline = 'all' and tilez = 16 and sourceid='all' and (tilex, tiley, periodstartdate, periodenddate) >= (100, 105, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (100, 302, '2017-06-30', '2017-06-30');
 
-//Pull all the conjunctive filter combinations for the most popular topic
 insert into topicconjunctions(topic, topicconjunctionid, conjunctivekeywordcombination) values ('isis', uuid(), {'bomb': 123, 'terror': 100, 'car': 834});
 
 select * from topicconjunctions where topic = 'isis';

--- a/ops/storage-ddls/cassandra-usage-queries.cql
+++ b/ops/storage-ddls/cassandra-usage-queries.cql
@@ -1,13 +1,17 @@
-cassandra@cqlsh:fortis> insert into streams (pipelinekey,pipelinelabel,connectorid,params) values ('twitter', 'Twitter', uuid(), {'connName':'Test'});
-cassandra@cqlsh:fortis> select * from streams where pipelinekey = 'twitter';
+insert into streams (streamid, pipelinekey, pipelinelabel, streamfactory, params) values (uuid(), 'instagram', 'Instagram', 'InstagramTag', {'connName':'Test'});
+insert into streams (streamid, pipelinekey, pipelinelabel, streamfactory, params) values (uuid(), 'instagram', 'Instagram', 'InstagramLocation', {'connName':'Test'});
 
- pipelinekey | connectorid                          | params               | pipelinelabel
--------------+--------------------------------------+----------------------+---------------
-     twitter | 7a6232bc-7a25-43fd-b34d-4eb40490814e | {'connName': 'Test'} |       Twitter
+select * from streams where pipelinekey = 'instagram';
 
-(1 rows)
+ pipelinekey | streamfactory     | params               | pipelineicon | pipelinelabel
+-------------+-------------------+----------------------+--------------+---------------
+   instagram | InstagramLocation | {'connName': 'Test'} |         null |     Instagram
+   instagram |      InstagramTag | {'connName': 'Test'} |         null |     Instagram
 
-cassandra@cqlsh:fortis> insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('@bloomberg', 'profile', 'twitter', 1, dateof(now()));
+(2 rows)
+
+insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('@bloomberg', 'profile', 'twitter', 1, dateof(now()));
+insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('kevhartman', 'profile', ' ', 1, dateof(now()));
 cassandra@cqlsh:fortis> select * from trustedsources where pipelinekey = 'twitter' ;
 
  pipelinekey | externalsourceid | sourcetype | rank | insertion_time
@@ -17,18 +21,20 @@ cassandra@cqlsh:fortis> select * from trustedsources where pipelinekey = 'twitte
      twitter |             @cnn |    profile |    2 | 2017-07-12 02:19:40.007000+0000
 
 
-insert into computedtiles (tileid, tilex, tiley, tilez, periodstartdate, periodenddate, periodtype, period, pipeline, sourceid, topiconjunctionid) VALUES ('100_105_16', 100, 106, 16, '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02);
+insert into computedtiles (tileid, tilex, tiley, tilez, periodstartdate, periodenddate, periodtype, period, pipeline, sourceid, topicconjunctionid) VALUES ('100_105_16', 100, 106, 16, '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02);
 
- select * from computedtiles where period = 'month-2017-06' and periodtype = 'month' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipeline = 'all' and tilez = 16 and sourceid='all' and (tilex, tiley, periodstartdate, periodenddate) >= (100, 105, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (100, 302, '2017-06-30', '2017-06-30');
+ select * from computedtiles where period = 'month-2017-06' and periodtype = 'month' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipeline = 'all' and tilez = 16 and sourceid='all' and (tilex, tiley, periodstartdate, periodenddate) >= (100, 105, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (100, 302, '2017-06-30', '2017-06-30');
 
 //Pull all the conjunctive filter combinations for the most popular topic
-select * from topiconjunctions where topic = 'isis';
+insert into topicconjunctions(topic, topicconjunctionid, conjunctivekeywordcombination) values ('isis', uuid(), {'bomb': 123, 'terror': 100, 'car': 834});
 
-insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topiconjunctionid, placename) VALUES ('232344', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'london';
+select * from topicconjunctions where topic = 'isis';
 
-insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topiconjunctionid, placename) VALUES ('34345', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'sydney');
+insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topicconjunctionid, placename) VALUES ('232344', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'london';
 
- select * from computedplaces where period = 'month-2017-06' and periodtype = 'month' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipelinekey = 'all' and externalsourceid='all' and placeid IN('34345') and (periodstartdate, periodenddate) >= ('2017-06-01', '2017-06-01') and (periodstartdate, periodenddate) <= ('2017-06-30', '2017-06-30');
+insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topicconjunctionid, placename) VALUES ('34345', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'sydney');
+
+ select * from computedplaces where period = 'month-2017-06' and periodtype = 'month' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipelinekey = 'all' and externalsourceid='all' and placeid IN('34345') and (periodstartdate, periodenddate) >= ('2017-06-01', '2017-06-01') and (periodstartdate, periodenddate) <= ('2017-06-30', '2017-06-30');
 
 insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentionCount, insertion_time) values ('elections', 'en', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 400, dateof(now()));
 
@@ -36,10 +42,14 @@ insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate,
 
 select * from populartopics where topiclangcode = 'en' and period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'all' and externalsourceid = 'all' and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@al jazeera', 'twitter', 400, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@al jazeera', 'twitter', 400, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@bloomberg', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@bloomberg', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
 
-insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@reuters', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topicconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@reuters', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
 
-select * from popularsources where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'twitter' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+select * from popularsources where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'twitter' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+
+select * from popularplaces where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'all' and externalsourceid = 'all' and topicconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+
+select * from events where pipelinekey = 'twitter' and eventlangcode = 'en' and topicconjunctionids CONTAINS 'facd7900-55cb-4fc5-844a-555c354cfe02';

--- a/ops/storage-ddls/cassandra-usage-queries.cql
+++ b/ops/storage-ddls/cassandra-usage-queries.cql
@@ -1,0 +1,45 @@
+cassandra@cqlsh:fortis> insert into streams (pipelinekey,pipelinelabel,connectorid,params) values ('twitter', 'Twitter', uuid(), {'connName':'Test'});
+cassandra@cqlsh:fortis> select * from streams where pipelinekey = 'twitter';
+
+ pipelinekey | connectorid                          | params               | pipelinelabel
+-------------+--------------------------------------+----------------------+---------------
+     twitter | 7a6232bc-7a25-43fd-b34d-4eb40490814e | {'connName': 'Test'} |       Twitter
+
+(1 rows)
+
+cassandra@cqlsh:fortis> insert into trustedsources (externalsourceid, sourcetype, pipelinekey, rank, insertion_time) values ('@bloomberg', 'profile', 'twitter', 1, dateof(now()));
+cassandra@cqlsh:fortis> select * from trustedsources where pipelinekey = 'twitter' ;
+
+ pipelinekey | externalsourceid | sourcetype | rank | insertion_time
+-------------+------------------+------------+------+---------------------------------
+     twitter |       @aljazeera |    profile |    1 | 2017-07-12 02:19:15.922000+0000
+     twitter |       @bloomberg |    profile |    1 | 2017-07-12 02:20:23.430000+0000
+     twitter |             @cnn |    profile |    2 | 2017-07-12 02:19:40.007000+0000
+
+
+insert into computedtiles (tileid, tilex, tiley, tilez, periodstartdate, periodenddate, periodtype, period, pipeline, sourceid, topiconjunctionid) VALUES ('100_105_16', 100, 106, 16, '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02);
+
+ select * from computedtiles where period = 'month-2017-06' and periodtype = 'month' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipeline = 'all' and tilez = 16 and sourceid='all' and (tilex, tiley, periodstartdate, periodenddate) >= (100, 105, '2017-06-01', '2017-06-01') and (tilex, tiley, periodstartdate, periodenddate) <= (100, 302, '2017-06-30', '2017-06-30');
+
+//Pull all the conjunctive filter combinations for the most popular topic
+select * from topiconjunctions where topic = 'isis';
+
+insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topiconjunctionid, placename) VALUES ('232344', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'london';
+
+insert into computedplaces (placeid, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, topiconjunctionid, placename) VALUES ('34345', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', facd7900-55cb-4fc5-844a-555c354cfe02, 'sydney');
+
+ select * from computedplaces where period = 'month-2017-06' and periodtype = 'month' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and pipelinekey = 'all' and externalsourceid='all' and placeid IN('34345') and (periodstartdate, periodenddate) >= ('2017-06-01', '2017-06-01') and (periodstartdate, periodenddate) <= ('2017-06-30', '2017-06-30');
+
+insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentionCount, insertion_time) values ('elections', 'en', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 400, dateof(now()));
+
+insert into populartopics (topic, topiclangcode, periodstartdate, periodenddate, periodtype, period, pipelinekey, externalsourceid, mentionCount, insertion_time) values ('isis', 'en', '2017-06-01', '2017-06-30', 'month', 'month-2017-06', 'all', 'all', 100, dateof(now()));
+
+select * from populartopics where topiclangcode = 'en' and period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'all' and externalsourceid = 'all' and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;
+
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@al jazeera', 'twitter', 400, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@bloomberg', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+
+insert into popularsources (periodstartdate, periodenddate, periodtype, period, externalsourceid, pipelinekey, mentionCount, topiconjunctionid, insertion_time) values ('2017-06-01', '2017-06-30', 'month', 'month-2017-06', '@reuters', 'twitter', 250, facd7900-55cb-4fc5-844a-555c354cfe02, dateof(now()));
+
+select * from popularsources where period = 'month-2017-06' and periodtype = 'month' and pipelinekey = 'twitter' and topiconjunctionid = facd7900-55cb-4fc5-844a-555c354cfe02 and (mentionCount, periodstartdate, periodenddate) >= (1, '2017-06-01', '2017-06-01') and (mentionCount, periodstartdate, periodenddate) <= (100000, '2017-06-30', '2017-06-30') LIMIT 1;

--- a/ops/upgrade-spark.sh
+++ b/ops/upgrade-spark.sh
@@ -12,6 +12,6 @@ readonly SparkCommand="wget \"https://fortiscentral.blob.core.windows.net/jars/$
 
 cd charts || exit -2
 
-helm upgrade --set Worker.Replicas="${k8spark_worker_count}" --set Master.ConfigMapName="${ConfigMapName}" --set Master.SparkSubmitCommand="${SparkCommand}" --name spark-cluster ./stable/spark --namespace spark
+helm upgrade --set Worker.Replicas="${k8spark_worker_count}" --set Master.ConfigMapName="${ConfigMapName}" --set Master.SparkSubmitCommand="${SparkCommand}" spark-cluster ./stable/spark --namespace spark
 
 cd .. || exit -2


### PR DESCRIPTION
- refactored all our cassandra tables to avoid querying the dataset with secondary indices(aside from the full text search indexes for `events`). The new data structure also minimizes the risk of needing to query our datasets with the scary `ALLOW FILTERING` option.  
- Also included `cassandra-usage-queries` to outline how data should be inserted and queried for all tables. 