### PR TITLE
Simplify sentiment persistence

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -7,12 +7,6 @@ USE fortis;
  * Types
  *****************************************************************************/
 
-DROP TYPE IF EXISTS computedsentiment;
-CREATE TYPE computedsentiment (
-    pos_avg float,
-    neg_avg float
-);
-
 DROP TYPE IF EXISTS computedgender;
 CREATE TYPE computedgender (
     male_mentions int,
@@ -30,7 +24,7 @@ CREATE TYPE computedentities (
 DROP TYPE IF EXISTS features;
 CREATE TYPE features (
     mentions int,
-    sentiment frozen<computedsentiment>,
+    sentiment float,
     gender frozen<computedgender>,
     entities frozen<set<computedentities>>
 );
@@ -130,7 +124,7 @@ CREATE TABLE computedtiles (
     tiley int,
     externalsourceid text,
     mentioncount int,
-    avgsentiment int,
+    avgsentiment float,
     heatmap text,
     placeids frozen<set<text>>,
     insertion_time timestamp,


### PR DESCRIPTION
The vast majority of services give us a sentiment in the range of
`(negative)0 -- 0.6(neutral) -- 1(positive)`

So it's much easier for us to store the sentiment value as a single float. Also note that the frontend also requires the sentiment as a single value (there are two values specified in the graphql schema but only one of them is used by the client) which is further evidence that we should only store one value.

Additionally, all sentiments (computedsentiment and avgsentiment) should be the same number type so converting the computedtiles column from int to float.