### PR TITLE
Cassandra data structures refactor

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -15,7 +15,6 @@ CREATE TYPE computedgender (
 
 DROP TYPE IF EXISTS sentiment;
 CREATE TYPE sentiment (
-    pos_avg float,
     neg_avg float
 );
 
@@ -122,7 +121,7 @@ CREATE TABLE populartopics (
     tiley int,
     externalsourceid text,
     topic text,
-    mentioncount counter,
+    mentioncount bigint,
     insertiontime timestamp,
     PRIMARY KEY ((periodtype, pipelinekey, externalsourceid, tilez, topic, period), tilex, tiley, periodstartdate, periodenddate)
 );
@@ -132,13 +131,13 @@ CREATE TABLE computedtiles (
     periodstartdate timestamp,
     periodenddate timestamp,
     periodtype text,
-    pipelinekey text,
+        pipelinekey text,
     period text,
     tilez int,
     tilex int,
     tiley int,
     externalsourceid text,
-    mentioncount counter,
+    mentioncount bigint,
     avgsentiment float,
     heatmap text,
     placeids frozen<set<text>>,
@@ -158,12 +157,13 @@ CREATE TABLE popularplaces (
     placeid text,
     centroidlat double,
     centroidlon double,
-    conjunctiontopics tuple<text, text, text>,
+    conjunctiontopic1 text,
+    conjunctiontopic2 text,
+    conjunctiontopic3 text,
     mentioncount bigint,
     insertiontime timestamp,
-    avgnegsentiment float,
-    avgpossentiment float,
-    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopics), mentioncount, periodstartdate, periodenddate, centroidlat, centroidlon)
+    avgsentiment float,
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), mentioncount, periodstartdate, periodenddate, centroidlat, centroidlon)
 ) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, centroidlat DESC, centroidlon DESC);
 
 DROP TABLE IF EXISTS eventtags;

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -253,14 +253,6 @@ PRIMARY KEY ((periodtype, conjunctiontopics, tilez, period), tilex, tiley, pipel
  * Indices
  *****************************************************************************/
 
-CREATE CUSTOM INDEX ON events (messagebody) USING 'org.apache.cassandra.index.sasi.SASIIndex'
-    detectedkeywords frozen<set<text>>,
-    detectedplaceids frozen<set<text>>,
-    insertiontime timestamp,
-    eventtime timestamp,
-    PRIMARY KEY ((pipelinekey, eventid), eventtime)
-) WITH CLUSTERING ORDER BY (eventtime ASC);
-
 CREATE CUSTOM INDEX ON events (body) USING 'org.apache.cassandra.index.sasi.SASIIndex'
 WITH OPTIONS = {
 'mode': 'CONTAINS',

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -9,8 +9,14 @@ USE fortis;
 
 DROP TYPE IF EXISTS computedgender;
 CREATE TYPE computedgender (
-    male_mentions counter,
-    female_mentions counter
+    male_mentions bigint,
+    female_mentions bigint
+);
+
+DROP TYPE IF EXISTS sentiment;
+CREATE TYPE sentiment (
+    pos_avg float,
+    neg_avg float
 );
 
 DROP TYPE IF EXISTS computedentities;
@@ -18,15 +24,24 @@ CREATE TYPE computedentities (
     name text,
     externalsource text,
     externalrefid text,
-    count counter
+    count bigint
+);
+
+DROP TYPE IF EXISTS place;
+CREATE TYPE place (
+    placeid text,
+    centroidlat double, 
+    centroidlon double
 );
 
 DROP TYPE IF EXISTS features;
 CREATE TYPE features (
-    mentions int,
-    sentiment float,
+    mentions bigint,
+    sentiment frozen<sentiment>,
     gender frozen<computedgender>,
-    entities frozen<set<computedentities>>
+    entities frozen<list<computedentities>>,
+    keywords frozen<list<text>>,
+    places frozen<list<place>>
 );
 
 /******************************************************************************
@@ -39,7 +54,7 @@ CREATE TABLE watchlist(
     topic text,
     lang_code text,
     translations map<text, text>,
-    insertion_time timestamp,
+    insertiontime timestamp,
     PRIMARY KEY (topic, lang_code)
 );
 
@@ -62,7 +77,7 @@ CREATE TABLE sitesettings(
     cogspeechsvctoken text,
     cogvisionsvctoken text,
     cogtextsvctoken text,
-    insertion_time timestamp,
+    insertiontime timestamp,
     PRIMARY KEY (sitename)
 );
 
@@ -83,7 +98,7 @@ CREATE TABLE trustedsources (
    sourcetype text,
    pipelinekey text,
    rank int,
-   insertion_time timestamp,
+   insertiontime timestamp,
    PRIMARY KEY (pipelinekey, externalsourceid, sourcetype, rank)
 );
 
@@ -91,9 +106,9 @@ DROP TABLE IF EXISTS conjunctivetopics;
 CREATE TABLE conjunctivetopics (
     topic text,
     conjunctivetopic text,
-    mentioncount counter,
-    PRIMARY KEY(topic, mentioncount, conjunctivetopic)
-) WITH CLUSTERING ORDER BY(mentioncount DESC);
+    mentioncount bigint,
+    PRIMARY KEY(topic, conjunctivetopic)
+);
 
 DROP TABLE IF EXISTS populartopics;
 CREATE TABLE populartopics (
@@ -108,7 +123,7 @@ CREATE TABLE populartopics (
     externalsourceid text,
     topic text,
     mentioncount counter,
-    insertion_time timestamp,
+    insertiontime timestamp,
     PRIMARY KEY ((periodtype, pipelinekey, externalsourceid, tilez, topic, period), tilex, tiley, periodstartdate, periodenddate)
 );
 
@@ -127,7 +142,7 @@ CREATE TABLE computedtiles (
     avgsentiment float,
     heatmap text,
     placeids frozen<set<text>>,
-    insertion_time timestamp,
+    insertiontime timestamp,
     conjunctiontopics tuple<text, text, text>,
     PRIMARY KEY ((periodtype, conjunctiontopics, tilez, period), tilex, tiley, periodstartdate, periodenddate, pipelinekey, externalsourceid)
 );
@@ -140,32 +155,34 @@ CREATE TABLE popularplaces (
     period text,
     pipelinekey text,
     externalsourceid text,
-    placename text,
     placeid text,
-    placecentroidcoordx double,
-    placecentroidcoordy double,
+    centroidlat double,
+    centroidlon double,
     conjunctiontopics tuple<text, text, text>,
-    mentioncount counter,
-    insertion_time timestamp,
-    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopics), mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy)
-) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, placecentroidcoordx DESC, placecentroidcoordy DESC);
+    mentioncount bigint,
+    insertiontime timestamp,
+    avgnegsentiment float,
+    avgpossentiment float,
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopics), mentioncount, periodstartdate, periodenddate, centroidlat, centroidlon)
+) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, centroidlat DESC, centroidlon DESC);
 
 DROP TABLE IF EXISTS eventtags;
 CREATE TABLE eventtags(
     eventid text,
     topic text,
+    centroidlat double,
+    centroidlon double,
     placeid text,
-    placecentroidcoordx double,
-    placecentroidcoordy double,
     eventtime timestamp,
     pipelinekey text,
     externalsourceid text,
-    PRIMARY KEY (topic, pipelinekey, eventtime, placecentroidcoordx, placecentroidcoordy, eventid)
+    PRIMARY KEY (topic, pipelinekey, eventtime, centroidlat, centroidlon, eventid)
 ) WITH CLUSTERING ORDER BY (pipelinekey DESC, eventtime ASC);
 
 DROP TABLE IF EXISTS events;
 CREATE TABLE events(
     eventid text,
+    batchid uuid,
     pipelinekey text,
     title text,
     sourceurl text,
@@ -175,8 +192,21 @@ CREATE TABLE events(
     computedfeatures frozen<features>,
     insertiontime timestamp,
     eventtime timestamp,
-    PRIMARY KEY ((pipelinekey, eventid), eventtime)
-) WITH CLUSTERING ORDER BY (eventtime ASC);
+    PRIMARY KEY ((pipelinekey, eventid)));
+
+/**
+ * Allows for linking the batchid to saveToCassandra spark call so we can filter out dupes from the original rdd.
+**/
+DROP MATERIALIZED VIEW IF EXISTS eventbatches;
+CREATE MATERIALIZED VIEW eventbatches
+AS SELECT batchid, eventid, pipelinekey, eventtime, computedfeatures, externalsourceid
+   FROM events
+   WHERE batchid IS NOT NULL
+     AND eventid IS NOT NULL
+     AND pipelinekey IS NOT NULL
+     AND eventtime IS NOT NULL
+     AND externalsourceid IS NOT NULL
+PRIMARY KEY (batchid, eventid, pipelinekey);
 
 /**
  * Allows for fetching trending topics given a pipeline, period and zoom level.

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -152,32 +152,31 @@ CREATE TABLE popularplaces (
 
 DROP TABLE IF EXISTS eventtags;
 CREATE TABLE eventtags(
-    eventid uuid,
+    eventid text,
     topic text,
     placeid text,
     placecentroidcoordx double,
     placecentroidcoordy double,
-    event_time timestamp,
+    eventtime timestamp,
     pipelinekey text,
     externalsourceid text,
-    PRIMARY KEY (topic, pipelinekey, event_time, placecentroidcoordx, placecentroidcoordy, eventid)
-) WITH CLUSTERING ORDER BY (pipelinekey DESC, event_time ASC);
+    PRIMARY KEY (topic, pipelinekey, eventtime, placecentroidcoordx, placecentroidcoordy, eventid)
+) WITH CLUSTERING ORDER BY (pipelinekey DESC, eventtime ASC);
 
 DROP TABLE IF EXISTS events;
 CREATE TABLE events(
-    eventid uuid,
-    externalid text,
+    eventid text,
     pipelinekey text,
     title text,
     sourceurl text,
     externalsourceid text,
     eventlangcode text,
-    messagebody text,
+    body text,
     computedfeatures frozen<features>,
-    insertion_time timestamp,
-    event_time timestamp,
-    PRIMARY KEY ((pipelinekey, eventid), event_time)
-) WITH CLUSTERING ORDER BY (event_time ASC);
+    insertiontime timestamp,
+    eventtime timestamp,
+    PRIMARY KEY ((pipelinekey, eventid), eventtime)
+) WITH CLUSTERING ORDER BY (eventtime ASC);
 
 /**
  * Allows for fetching trending topics given a pipeline, period and zoom level.
@@ -255,6 +254,14 @@ PRIMARY KEY ((periodtype, conjunctiontopics, tilez, period), tilex, tiley, pipel
  *****************************************************************************/
 
 CREATE CUSTOM INDEX ON events (messagebody) USING 'org.apache.cassandra.index.sasi.SASIIndex'
+    detectedkeywords frozen<set<text>>,
+    detectedplaceids frozen<set<text>>,
+    insertiontime timestamp,
+    eventtime timestamp,
+    PRIMARY KEY ((pipelinekey, eventid), eventtime)
+) WITH CLUSTERING ORDER BY (eventtime ASC);
+
+CREATE CUSTOM INDEX ON events (body) USING 'org.apache.cassandra.index.sasi.SASIIndex'
 WITH OPTIONS = {
 'mode': 'CONTAINS',
 'analyzer_class': 'org.apache.cassandra.index.sasi.analyzer.StandardAnalyzer',

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -9,8 +9,8 @@ USE fortis;
 
 DROP TYPE IF EXISTS computedgender;
 CREATE TYPE computedgender (
-    male_mentions int,
-    female_mentions int
+    male_mentions counter,
+    female_mentions counter
 );
 
 DROP TYPE IF EXISTS computedentities;
@@ -18,7 +18,7 @@ CREATE TYPE computedentities (
     name text,
     externalsource text,
     externalrefid text,
-    count float
+    count counter
 );
 
 DROP TYPE IF EXISTS features;
@@ -91,9 +91,9 @@ DROP TABLE IF EXISTS conjunctivetopics;
 CREATE TABLE conjunctivetopics (
     topic text,
     conjunctivetopic text,
-    mentions int,
-    PRIMARY KEY(topic, mentions, conjunctivetopic)
-) WITH CLUSTERING ORDER BY(mentions DESC);
+    mentioncount counter,
+    PRIMARY KEY(topic, mentioncount, conjunctivetopic)
+) WITH CLUSTERING ORDER BY(mentioncount DESC);
 
 DROP TABLE IF EXISTS populartopics;
 CREATE TABLE populartopics (
@@ -107,7 +107,7 @@ CREATE TABLE populartopics (
     tiley int,
     externalsourceid text,
     topic text,
-    mentionCount int,
+    mentioncount counter,
     insertion_time timestamp,
     PRIMARY KEY ((periodtype, pipelinekey, externalsourceid, tilez, topic, period), tilex, tiley, periodstartdate, periodenddate)
 );
@@ -123,7 +123,7 @@ CREATE TABLE computedtiles (
     tilex int,
     tiley int,
     externalsourceid text,
-    mentioncount int,
+    mentioncount counter,
     avgsentiment float,
     heatmap text,
     placeids frozen<set<text>>,
@@ -145,7 +145,7 @@ CREATE TABLE popularplaces (
     placecentroidcoordx double,
     placecentroidcoordy double,
     conjunctiontopics tuple<text, text, text>,
-    mentioncount int,
+    mentioncount counter,
     insertion_time timestamp,
     PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopics), mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy)
 ) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, placecentroidcoordx DESC, placecentroidcoordy DESC);

--- a/ops/storage-ddls/cassandra-usage-queries.cql
+++ b/ops/storage-ddls/cassandra-usage-queries.cql
@@ -52,11 +52,11 @@ insert into popularplaces (periodstartdate, periodenddate, period, periodtype, e
 
 select period, periodtype, pipelinekey, externalsourceid, conjunctiontopics, mentioncount, placename from popularplaces where conjunctiontopics = ('isis', 'car') and periodtype = 'month' and externalsourceid = 'all' and pipelinekey = 'all' and period IN('month-2017-06') and (mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy) >= (1, '2017-06-01', '2017-06-01', 22, -33) and (mentioncount, periodstartdate, periodenddate, placecentroidcoordx, placecentroidcoordy) <= (100000000, '2017-06-30', '2017-06-30', 26, 0) LIMIT 1;
 
-insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, event_time, pipelinekey, externalsourceid) values (uuid(), 'isis', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
+insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, eventtime, pipelinekey, externalsourceid) values (uuid(), 'isis', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
 
-insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, event_time, pipelinekey, externalsourceid) values (ac01cb69-1684-4b5e-9016-7a4f0dcde074, 'car', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
+insert into eventtags(eventid, topic, placeid, placecentroidcoordx, placecentroidcoordy, eventtime, pipelinekey, externalsourceid) values (ac01cb69-1684-4b5e-9016-7a4f0dcde074, 'car', '455633', 12.43434, -45.3434, '2017-06-30', 'twitter', 'cnn');
 
-select eventid, pipelinekey, event_time from eventtags where topic IN('isis', 'car') and pipelinekey IN('twitter', 'facebook') and (event_time, placecentroidcoordx, placecentroidcoordy) >= ('2017-06-01', 12, -46) and (event_time, placecentroidcoordx, placecentroidcoordy) <= ('2017-07-15', 12, -44);
+select eventid, pipelinekey, eventtime from eventtags where topic IN('isis', 'car') and pipelinekey IN('twitter', 'facebook') and (eventtime, placecentroidcoordx, placecentroidcoordy) >= ('2017-06-01', 12, -46) and (eventtime, placecentroidcoordx, placecentroidcoordy) <= ('2017-07-15', 12, -44);
 
 select * from events where eventid IN(609a367a-c536-46a9-aee0-415625e8ff43, 7c0933b9-f6d1-417a-a7b2-fb738aad441c) and pipelinekey IN('twitter');
 


### PR DESCRIPTION
This PR encompasses the following changes.

- Changed the columns names to enforce naming convention consistency across all C* tables ie `mentionCount` `mentioncount`. 
- Changed the data type for all accumulative related fields to be a true `counter` as opposed to a `int`.