### PR TITLE
Simplify events table schema

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -202,6 +202,8 @@ CREATE TABLE events(
     computedfeatures frozen<features>,
     insertiontime timestamp,
     eventtime timestamp,
+    topics frozen<set<text>>,
+    placeids frozen<set<text>>,
     fulltext text, /* conjunction of title and body to enable querying of both at the same time */
     PRIMARY KEY ((pipelinekey, eventid)));
 


### PR DESCRIPTION
See the use case described in [c65e3b6](https://github.com/CatalystCode/project-fortis-services/commit/c65e3b6970bb4c767394f3e3e5179cfa607bfb1b):

By adding non-queryable columns to the events table that contain all of an events places and topics, we can re-build a full event just from the data that we get back from that table. This makes a number of queries easier and more performant, including the MessagesSchema.event query.