### PR TITLE
Split eventtags table into sub-tables

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -166,18 +166,37 @@ CREATE TABLE popularplaces (
     PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), mentioncount, periodstartdate, periodenddate, centroidlat, centroidlon)
 ) WITH CLUSTERING ORDER BY (mentioncount DESC, periodstartdate DESC, periodenddate DESC, centroidlat DESC, centroidlon DESC);
 
-DROP TABLE IF EXISTS eventtags;
-CREATE TABLE eventtags(
-    eventid text,
+DROP TABLE IF EXISTS eventtopics;
+CREATE TABLE eventtopics(
+    eventids set<text>,
     topic text,
-    centroidlat double,
-    centroidlon double,
+    eventtime timestamp,
+    pipelinekey text,
+    externalsourceid text,
+    PRIMARY KEY ((topic), pipelinekey, externalsourceid, eventtime)
+);
+
+DROP TABLE IF EXISTS mentionedtopics;
+CREATE TABLE mentionedtopics(
+    topics set<text>,
+    eventtime timestamp,
+    pipelinekey text,
+    externalsourceid text,
+    PRIMARY KEY (pipelinekey, externalsourceid, eventtime)
+);
+
+DROP TABLE IF EXISTS eventplaces;
+CREATE TABLE eventplaces(
+    eventids set<text>,
+    conjunctiontopic1 text,
+    conjunctiontopic2 text,
+    conjunctiontopic3 text,
     placeid text,
     eventtime timestamp,
     pipelinekey text,
     externalsourceid text,
-    PRIMARY KEY (topic, pipelinekey, eventtime, centroidlat, centroidlon, eventid)
-) WITH CLUSTERING ORDER BY (pipelinekey DESC, eventtime ASC);
+    PRIMARY KEY ((placeid), conjunctiontopic1, conjunctiontopic2, conjunctiontopic3, pipelinekey, externalsourceid, eventtime)
+);
 
 DROP TABLE IF EXISTS events;
 CREATE TABLE events(

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -176,15 +176,6 @@ CREATE TABLE eventtopics(
     PRIMARY KEY ((topic), pipelinekey, externalsourceid, eventtime)
 );
 
-DROP TABLE IF EXISTS mentionedtopics;
-CREATE TABLE mentionedtopics(
-    topics set<text>,
-    eventtime timestamp,
-    pipelinekey text,
-    externalsourceid text,
-    PRIMARY KEY (pipelinekey, externalsourceid, eventtime)
-);
-
 DROP TABLE IF EXISTS eventplaces;
 CREATE TABLE eventplaces(
     eventids set<text>,


### PR DESCRIPTION
See usage example in [63fd942](https://github.com/CatalystCode/project-fortis-services/commit/63fd9420bb401a92d2a0afc517a3e9601edf122b).

The *eventtopics* table is used in the MessagesSchema.byEdges query where we need to find all the events for a particular set of keywords. This is why we index the table on the topics and link the eventids.

The *mentionedtopics* table is used in the EdgesSchema.terms query to find all the keywords for a particular time period. We can't re-use the eventtopics table since we don't have access to a topic here.

The *eventplaces* table is used in the MessagesSchema.byBbox query to find all the events for a particular keyword combination, timespan and bounding box. Potentially this table can be further simplified to index off of tile-{x,y,z} instead of placeid if we pass through the zoom-level from the frontend. This would allow us to get rid of the query to the featureService.