### PR TITLE
Change spark's app insights key name

### DIFF
--- a/ops/setup-environment.sh
+++ b/ops/setup-environment.sh
@@ -29,7 +29,7 @@ kubectl create configmap "${spark_config_map_name}" --namespace spark \
 --from-literal=FORTIS_CASSANDRA_HOST="${cassandra_host}" \
 --from-literal=FORTIS_FEATURE_SERVICE_HOST="${feature_service_host}" \
 --from-literal=DEFAULT_SITE_NAME="${site_name}" \
---from-literal=FORTIS_APPINSIGHTS_IKEY="${app_insights_id}" \
+--from-literal=APPLICATION_INSIGHTS_IKEY="${app_insights_id}" \
 --from-literal=SPARK_DAEMON_MEMORY="${SPARK_DAEMON_MEMORY}" \
 --from-literal=HA_PROGRESS_DIR="${checkpoint_directory}" \
 --from-literal=DEFAULT_LANGUAGE="${default_language}" \


### PR DESCRIPTION
The Application Insights telemetry client library used by the Spark job looks for the app insights key in the environment under key name `APPLICATION_INSIGHTS_IKEY`. This is not configurable. A corresponding change will also be made in project-fortis-spark for diagnostic logging.