### PR TITLE
Fix feature-db setup script with new dump

### DIFF
--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -4,7 +4,7 @@ fs__location="$1"
 fs__resource_group="$2"
 
 fs__randomString() { < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"$1"; }
-fs__randomId() {  < /dev/urandom tr -dc a-z0-9 | head -c"$1"; }
+fs__randomId() { < /dev/urandom tr -dc a-z0-9 | head -c"$1"; }
 
 fs__pg_dump="https://fortiscentral.blob.core.windows.net/locations/feature-service.v1.sql.gz"
 fs__pg_admin="${FEATUREDB_ADMIN:-fortisadmin}"

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -53,6 +53,8 @@ psql "postgresql://${fs__pg_host}:5432/features?user=${fs__pg_admin}@${fs__pg_na
 rm "${fs__dbdump}"
 
 FEATURE_SERVICE_DB_CONNECTION_STRING="postgres://frontend@${fs__pg_name}:${fs__pg_user_password_frontend}@${fs__pg_host}:5432/features?ssl=true"
+FEATURE_SERVICE_DB_CONNECTION_STRING_2="postgres://ops@${fs__pg_name}:${fs__pg_user_password_ops}@${fs__pg_host}:5432/features?ssl=true"
 export FEATURE_SERVICE_DB_CONNECTION_STRING
+export FEATURE_SERVICE_DB_CONNECTION_STRING_2
 
 echo "All done installing feature service database"

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -6,14 +6,14 @@ fs__resource_group="$2"
 fs__randomString() { < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"$1"; }
 fs__randomId() { < /dev/urandom tr -dc a-z0-9 | head -c"$1"; }
 
-fs__pg_dump="https://fortiscentral.blob.core.windows.net/locations/feature-service.v1.sql.gz"
+fs__pg_dump="https://fortiscentral.blob.core.windows.net/locations/feature-service.v2.sql.gz"
 fs__pg_admin="${FEATUREDB_ADMIN:-fortisadmin}"
 fs__pg_user="${FEATUREDB_USER:-frontend}"
 fs__pg_name="${FEATUREDB_NAME:-fortis-feature-service-db-$(fs__randomId 8)}"
 fs__pg_tier="${FEATUREDB_TIER:-Basic}"
 fs__pg_compute="${FEATUREDB_COMPUTEUNITS:-50}"
 fs__pg_version="${FEATUREDB_POSTGRESVERSION:-9.6}"
-fs__pg_dbname="${FEATUREDB_DBNAME:-geofeatures}"
+fs__pg_dbname="${FEATUREDB_DBNAME:-features}"
 fs__pg_user_password="$(fs__randomString 32)"
 fs__pg_admin_password="$(fs__randomString 32)"
 

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -28,7 +28,7 @@ az postgres server create \
   --admin-password "${fs__pg_admin_password}" \
   --performance-tier "${fs__pg_tier}" \
   --compute-units "${fs__pg_compute}" \
-  --version "${fs__pg_version}"
+  --version "${fs__pg_version}" > /dev/null
 
 echo "Finished. Now opening up database server firewall"
 az postgres server firewall-rule create \
@@ -36,7 +36,7 @@ az postgres server firewall-rule create \
   --server "${fs__pg_name}" \
   --name AllowAllIps \
   --start-ip-address 0.0.0.0 \
-  --end-ip-address 255.255.255.255
+  --end-ip-address 255.255.255.255 > /dev/null
 
 fs__dbdump="$(mktemp)"
 echo "Finished. Now downloading database dump to ${fs__dbdump}"

--- a/ops/install-feature-service-db.sh
+++ b/ops/install-feature-service-db.sh
@@ -45,7 +45,7 @@ curl "${fs__pg_dump}" | gunzip --to-stdout > "${fs__dbdump}"
 fs__pg_host="$(az postgres server show --resource-group "${fs__resource_group}" --name "${fs__pg_name}" | jq -r '.fullyQualifiedDomainName')"
 echo "Finished. Now populating the database hosted at ${fs__pg_host}"
 
-echo "CREATE DATABASE features; CREATE USER ops WITH login PASSWORD '${fs__pg_user_password_ops}'; CREATE USER frontend WITH login PASSWORD '${fs__pg_user_password_frontend}';" | \
+echo "CREATE DATABASE features; CREATE USER ops WITH login PASSWORD '${fs__pg_user_password_ops}'; CREATE USER frontend WITH login PASSWORD '${fs__pg_user_password_frontend}'; GRANT ops TO ${fs__pg_admin}; GRANT frontend TO ${fs__pg_admin};" | \
 psql "postgresql://${fs__pg_host}:5432/postgres?user=${fs__pg_admin}@${fs__pg_name}&password=${fs__pg_admin_password}&ssl=true"
 
 < "${fs__dbdump}" \


### PR DESCRIPTION
A few changes were necessary to make this work with Tim's latest dump:
1) Remove some extension points (user name, database name) as the dump assumes them
2) Export two connection strings since the dump assumes two users being set up

Verified that the script runs without issues like so:

```bash
# these are normally be set by the fortis-deploy.sh script, setting manually for testing
region='EastUS'
resource_group='clewolff-test-db'

# call the script to create and populate the feature-db
# this takes ~30 minutes to download the database dump and a few hours to populate the db
. ./install-feature-service-db.sh "$region" "$resource_group"

# verify the connection strings; normally these would be stored in the cluster config map
echo "$FEATURE_SERVICE_DB_CONNECTION_STRING"
echo "$FEATURE_SERVICE_DB_CONNECTION_STRING_2"
```