### PR TITLE
Fix popularplaces table for edges queries

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -182,7 +182,6 @@ CREATE TABLE popularplaces (
     pipelinekey text,
     externalsourceid text,
     placeid text,
-    placename text,
     centroidlat double,
     centroidlon double,
     conjunctiontopic1 text,
@@ -190,7 +189,7 @@ CREATE TABLE popularplaces (
     conjunctiontopic3 text,
     mentioncount counter,
     avgsentimentnumerator counter,
-    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), periodstartdate, periodenddate, centroidlat, centroidlon, placeid, placename)
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), periodstartdate, periodenddate, centroidlat, centroidlon, placeid)
 );
 
 CREATE TABLE eventtopics(

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -182,6 +182,7 @@ CREATE TABLE popularplaces (
     pipelinekey text,
     externalsourceid text,
     placeid text,
+    placename text,
     centroidlat double,
     centroidlon double,
     conjunctiontopic1 text,
@@ -189,7 +190,7 @@ CREATE TABLE popularplaces (
     conjunctiontopic3 text,
     mentioncount counter,
     avgsentimentnumerator counter,
-    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), placeid, centroidlat, centroidlon, periodstartdate, periodenddate)
+    PRIMARY KEY ((period, periodtype, pipelinekey, externalsourceid, conjunctiontopic1, conjunctiontopic2, conjunctiontopic3), periodstartdate, periodenddate, centroidlat, centroidlon, placeid, placename)
 );
 
 CREATE TABLE eventtopics(


### PR DESCRIPTION
We query the popularplaces table like this:

```cql
    SELECT placeid, mentioncount, centroidlat, centroidlon
    FROM fortis.popularplaces
    WHERE period = ?
    AND periodtype = ?
    AND pipelinekey = ?
    AND externalsourceid = ?
    AND conjunctiontopic1 = ?
    AND conjunctiontopic2 = ?
    AND conjunctiontopic3 = ?
    AND (periodstartdate, periodenddate) <= (?, ?)
    AND (periodstartdate, periodenddate) >= (?, ?)
```

So we need to jiggle around some of the column keys so that we can query on period{start,end}date.