### PR TITLE
Remove pipelinekey

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -231,7 +231,8 @@ CREATE TABLE events(
     topics frozen<set<text>>,
     placeids frozen<set<text>>,
     fulltext text, /* conjunction of title and body to enable querying of both at the same time */
-    PRIMARY KEY ((pipelinekey, eventid)));
+    PRIMARY KEY (eventid)
+);
 
 /**
  * Allows for linking the batchid to saveToCassandra spark call so we can filter out dupes from the original rdd.

--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -218,6 +218,7 @@ CREATE TABLE eventplaces(
 
 CREATE TABLE events(
     eventid text,
+    sourceeventid text,
     batchid uuid,
     pipelinekey text,
     title text,


### PR DESCRIPTION
We query the table like so:

```cql
    SELECT *
    FROM fortis.events
    WHERE eventid = ?
    LIMIT 2
```

When we query the table, we don't know what pipeline the event came from (it's in the messages schema `event` endpoint which just retrieves an event by id). This means that either we have to `ALLOW FILTERING` here or we must remove the pipelinekey from the table primary key. Given that the eventids will be unique (we generate them in Spark), I don't see an issue with just removing the pipelinekey here.