### PR TITLE
Call GraphQL createSite during deployment

### DIFF
--- a/fortis-deploy.sh
+++ b/fortis-deploy.sh
@@ -268,4 +268,5 @@ chmod 752 create-cluster.sh
     "${app_insights_id}" \
     "${site_name}" \
     "${eh_conn_str}" \
-    "${sb_conn_str}"
+    "${sb_conn_str}" \
+    "${site_type}"

--- a/ops/create-cluster.sh
+++ b/ops/create-cluster.sh
@@ -9,6 +9,7 @@ readonly app_insights_id="$6"
 readonly site_name="$7"
 readonly eh_conn_str="$8"
 readonly sb_conn_str="$9"
+readonly site_type="${10}"
 
 chmod -R 752 .
 
@@ -34,7 +35,7 @@ echo "Finished. Now deploying"
 ./deis-apps/fortis-interface/deploy-app.sh
 echo "Finished. Now installing DEIS feature service"
 ./deis-apps/feature-service/create-app.sh
-echo "Finished."
+echo "Finished. Now deploying"
 ./deis-apps/feature-service/deploy-app.sh
 
 sleep 10
@@ -58,6 +59,9 @@ readonly feature_service_db_conn_str="${FEATURE_SERVICE_DB_CONNECTION_STRING}"
 readonly feature_service_host="http://feature-service.${DEIS_ROUTER_HOST_ROOT}.nip.io"
 readonly fortis_central_directory="https://fortiscentral.blob.core.windows.net/"
 readonly spark_config_map_name="spark-master-conf"
+
+echo "Finished. Now setting up site entry"
+./create-site.sh "${graphql_service_host}" "${site_name}" "${site_type}"
 
 echo "Finished. Installing cassandra cqlsh cli."
 ./storage-ddls/install-cassandra-ddls.sh "${cassandra_host}"

--- a/ops/create-site.sh
+++ b/ops/create-site.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+readonly graphql_service_host="$1"
+readonly site_name="$2"
+readonly site_type="$3"
+
+if ! (command -v python >/dev/null); then sudo apt-get install -y python; fi
+
+cat << EOF | python | curl "${graphql_service_host}/api/settings" -d@- -H "Content-Type: application/json"
+#
+# parameters included from bash via variable interpolation
+#
+siteType = '${site_type}'
+name = '${site_name}'
+
+#
+# python script to format graphql json request body
+#
+import json
+import sys
+
+query = '''mutation {
+  createSite(
+    input: {
+      siteType: "%s",
+      targetBbox: [],
+      defaultZoomLevel: 0,
+      logo: "",
+      title: "",
+      name: "%s",
+      defaultLocation: [],
+      storageConnectionString: "",
+      mapzenApiKey: "",
+      fbToken: "",
+      supportedLanguages: []
+    }
+  ) { name }
+}''' % (
+  siteType,
+  name,
+)
+
+payload = {
+  'query': query,
+}
+
+print(json.dumps(payload))
+EOF


### PR DESCRIPTION
Note that currently we can only pass the `siteType` and `name` to the createSite call since the deployment script doesn't have any other parameter available.