### PR TITLE
Switch to CMS GC

### DIFF
--- a/ops/install-spark.sh
+++ b/ops/install-spark.sh
@@ -11,7 +11,7 @@ readonly checkpointfileshare="$6"
 readonly gh_fortis_spark_repo_name="project-fortis-spark"
 readonly latest_version=$(curl "https://api.github.com/repos/catalystcode/${gh_fortis_spark_repo_name}/releases/latest" | jq -r '.tag_name')
 readonly fortis_jar="fortis-${latest_version}.jar"
-readonly SparkCommand="spark-submit --deploy-mode cluster --driver-memory 4g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
+readonly SparkCommand="spark-submit --conf \"spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --conf \"spark.driver.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --deploy-mode cluster --driver-memory 4g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
 
 cd charts || exit -2
 helm install --set Worker.Replicas="${k8spark_worker_count}" \

--- a/ops/upgrade-spark.sh
+++ b/ops/upgrade-spark.sh
@@ -8,7 +8,7 @@ readonly k8spark_worker_count="$2"
 readonly ConfigMapName="$3"
 readonly fortis_spark_version="${4:-$(curl "https://api.github.com/repos/catalystcode/${gh_fortis_spark_repo_name}/releases/latest" | jq -r '.tag_name')}"
 readonly fortis_jar="fortis-${fortis_spark_version}.jar"
-readonly SparkCommand="spark-submit --deploy-mode cluster --driver-memory 4g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
+readonly SparkCommand="spark-submit --conf \"spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --conf \"spark.driver.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --deploy-mode cluster --driver-memory 4g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
 
 cd charts || exit -2
 


### PR DESCRIPTION
By default, Java 8 uses Parallel GC. This is not desirable for streaming applications as it can lead to stop-the-world GC pauses which leads to unpredictable batch times.

For a streaming application, we want predictable times so that our events don't get backlogged. As such, using Concurrent Mark and Sweep GC is more suited since it is overall more expensive but has fewer large pauses.

You can read more about this topic [here](https://github.com/haoyuan/spark-tachyon/blob/master/docs/streaming-programming-guide.md#memory-tuning).