### PR TITLE
Add category field to watchlist table

### DIFF
--- a/ops/storage-ddls/cassandra-setup.cql
+++ b/ops/storage-ddls/cassandra-setup.cql
@@ -79,9 +79,12 @@ CREATE TABLE watchlist(
     topic text,
     lang_code text,
     translations map<text, text>,
+    category text,
     insertiontime timestamp,
-    PRIMARY KEY (topic, lang_code)
+    PRIMARY KEY ((topic, lang_code), category)
 );
+
+CREATE INDEX ON fortis.watchlist (category);
 
 CREATE TABLE blacklist(
     id uuid,


### PR DESCRIPTION
Also, this makes `category` a secondary index for the `watchlist` table.

*To query topics by category:* `select * from fortis.watchlist where category = 'armed conflict';`

This change is necessary for Columbia, which wants to view topics pertaining to a `category`.