### PR TITLE
Update install-spark script.

### DIFF
--- a/ops/install-spark.sh
+++ b/ops/install-spark.sh
@@ -11,15 +11,23 @@ readonly checkpointfileshare="$6"
 readonly gh_fortis_spark_repo_name="project-fortis-spark"
 readonly latest_version=$(curl "https://api.github.com/repos/catalystcode/${gh_fortis_spark_repo_name}/releases/latest" | jq -r '.tag_name')
 readonly fortis_jar="fortis-${latest_version}.jar"
-readonly SparkCommand="spark-submit --conf \"spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --conf \"spark.driver.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --deploy-mode cluster --driver-memory 4g --executor-memory 3g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
+readonly SparkCommand="spark-submit --conf \"spark.executor.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --conf \"spark.driver.extraJavaOptions=-XX:+UseConcMarkSweepGC\" --deploy-mode cluster --driver-memory 2g --executor-memory 18g --supervise --master spark://spark-master:7077 --verbose --class com.microsoft.partnercatalyst.fortis.spark.ProjectFortis \"https://fortiscentral.blob.core.windows.net/jars/${fortis_jar}\""
 
 cd charts || exit -2
 helm install --set Worker.Replicas="${k8spark_worker_count}" \
-             --set Master.ImageTag="2.2.0" \
-             --set Worker.ImageTag="2.2.0" \
+             --set Master.ImageTag="2.2" \
+             --set Worker.ImageTag="2.2" \
              --set Worker.ConfigMapName="${ConfigMapName}" \
              --set Master.ConfigMapName="${ConfigMapName}" \
              --set Master.SparkSubmitCommand="${SparkCommand}" \
-             --set Worker.Environment[0].name="SPARK_WORKER_MEMORY",Worker.Environment[0].value="3g" \
+             --set Worker.Resources.Requests.Cpu="1" \
+             --set Worker.Resources.Requests.Memory="10Gi" \
+             --set Worker.Resources.Limits.Cpu="2.8" \
+             --set Worker.Resources.Limits.Memory="20Gi" \
+             --set Master.Resources.Requests.Cpu="1" \
+             --set Master.Resources.Requests.Memory="3Gi" \
+             --set Master.Resources.Limits.Cpu="2" \
+             --set Master.Resources.Limits.Memory="5Gi" \
+             --set Worker.Environment[0].name="SPARK_WORKER_MEMORY",Worker.Environment[0].value="20g" \
              --name spark-cluster ./stable/spark --namespace spark
 cd ..


### PR DESCRIPTION
Changes
* Use correct spark 2.2 image. Previous version marked 2.2.0 is actually 2.1.
* Increase CPU and RAM to take advantage of unused resources in the cluster. We may want to tune these again along with other services running on our K8 cluster (for example, decrease Cassandra CPU and increase Spark).