### PR TITLE
Fix warning in deployment script logs

### DIFF
--- a/ops/install-spark.sh
+++ b/ops/install-spark.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! (command -v jq >/dev/null); then sudo apt install jq; fi
+if ! (command -v jq >/dev/null); then sudo apt-get install -y jq; fi
 
 readonly k8spark_worker_count="$1"
 readonly ConfigMapName="$2"

--- a/ops/upgrade-spark.sh
+++ b/ops/upgrade-spark.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! (command -v jq >/dev/null); then sudo apt install jq; fi
+if ! (command -v jq >/dev/null); then sudo apt-get install -y jq; fi
 
 readonly gh_fortis_spark_repo_name="project-fortis-spark"
 readonly fortis_central_directory="$1"


### PR DESCRIPTION
The warning is: "WARNING: apt does not have a stable CLI interface. Use with caution in scripts."

Additionally, this change will make all the apt install calls consistent in the project.