### PR TITLE
Remove double http prefix for graphql_service_host

### DIFF
--- a/ops/create-cluster.sh
+++ b/ops/create-cluster.sh
@@ -61,7 +61,7 @@ echo "Finished. Installing cassandra cqlsh cli."
 
 echo "Finished. Now setting up site entry"
 if ! (command -v python >/dev/null); then sudo apt-get install -y python; fi
-./create_site.py "http://${graphql_service_host}" "${site_name}" "${site_type}"
+./create_site.py "${graphql_service_host}" "${site_name}" "${site_type}"
 
 kubectl create -f ./spark-namespace.yaml
 echo "Finished. Deploying environment settings to cluster."


### PR DESCRIPTION
This fixes a regression introduced in 4737842 where the graphql_service_host variable was updated to include a http prefix but the dereference of the variable in the create_site.py script invocation was not updated which led to the script failing to find the graphql service host at http://http://the-uri-here