### PR TITLE
Enable deployment on DS4_v2

### DIFF
--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -12,7 +12,7 @@
             "value": 6
         },
         "agentVMSize": {
-            "value": "Standard_DS2"
+            "value": "Standard_L4s"
         },
         "dnsNamePrefix": {
             "value": "fortis"


### PR DESCRIPTION
This is the default VM size for our Cassandra chart so we should enable users to deploy Fortis to these VMs.

More background: https://github.com/CatalystCode/project-fortis-pipeline/pull/225