### PR TITLE
Add a default/dummy bounding box on site setup

### DIFF
--- a/ops/create_site.py
+++ b/ops/create_site.py
@@ -14,7 +14,7 @@ def _main(graphql_service_host, site_name, site_type):
       createSite(
         input: {
           siteType: "%s",
-          targetBbox: [],
+          targetBbox: [0, 0, 0, 0],
           defaultZoomLevel: 8,
           logo: "",
           title: "",


### PR DESCRIPTION
For more background on this change, please refer to the discussion in https://github.com/CatalystCode/project-fortis-pipeline/issues/233

@Smarker: Do you see any concerns for this change from an admin/editing perspective? It should be possible to edit the dummy bounding box after the deployment is finished, right?

@erikschlegel: Any objections to this change?